### PR TITLE
Feature/dist manylinux

### DIFF
--- a/dist-scripts/create-manylinux.sh
+++ b/dist-scripts/create-manylinux.sh
@@ -16,7 +16,7 @@ cd pyprophet
 git apply /data/manylinux.patch
 
 # Compile wheels
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp27*/bin /opt/python/cp3[4-9]*/bin; do
   "${PYBIN}/pip" install Cython
   "${PYBIN}/pip" install numpy
   "${PYBIN}/pip" install pandas

--- a/dist-scripts/create-manylinux.sh
+++ b/dist-scripts/create-manylinux.sh
@@ -1,29 +1,34 @@
 # Create manylinux packages from current release using the docker image
-
+#
 # based on https://github.com/pypa/python-manylinux-demo/blob/master/travis/build-wheels.sh
-
-# sudo docker run --net=host -v `pwd`:/data quay.io/pypa/manylinux1_x86_64 /bin/bash /data/create-manylinux.sh
+#
+# Execute as:
+# 
+#   sudo docker run --net=host -v `pwd`:/data quay.io/pypa/manylinux1_x86_64 /bin/bash /data/create-manylinux.sh
+#
 
 git clone https://github.com/PyProphet/pyprophet.git
 cd pyprophet
+# Apply patch that sets dependency to matplotlib 1.5.3 which does not depend on
+# subprocess32 (which cannot be properly installed under CentOS 5).
+# See https://github.com/matplotlib/matplotlib/issues/8361
+# See https://github.com/google/python-subprocess32/issues/12
 git apply /data/manylinux.patch
 
 # Compile wheels
-for PYBIN in /opt/python/*27*/bin; do
+for PYBIN in /opt/python/*/bin; do
   "${PYBIN}/pip" install Cython
   "${PYBIN}/pip" install numpy
   "${PYBIN}/pip" install pandas
-  "${PYBIN}/pip" wheel . -w wheelhouse/
+  "${PYBIN}/pip" wheel . -w wheelhouse_tmp/
 done
 
 # Bundle external shared libraries into the wheels
-for whl in wheelhouse/pyprophet*.whl; do
-    auditwheel repair "$whl" -w wheelhouse_final/
+for whl in wheelhouse_tmp/pyprophet*.whl; do
+    auditwheel repair "$whl" -w wheelhouse/
 done
 
 # upload / store result
-mv wheelhouse_final /data/
-## /opt/python/cp27-cp27mu/bin/pip install twine
-## /opt/python/cp27-cp27mu/bin/twine upload wheelhouse_final/* -u hroest
+mv wheelhouse /data/
 
 

--- a/dist-scripts/create-manylinux.sh
+++ b/dist-scripts/create-manylinux.sh
@@ -1,0 +1,29 @@
+# Create manylinux packages from current release using the docker image
+
+# based on https://github.com/pypa/python-manylinux-demo/blob/master/travis/build-wheels.sh
+
+# sudo docker run --net=host -v `pwd`:/data quay.io/pypa/manylinux1_x86_64 /bin/bash /data/create-manylinux.sh
+
+git clone https://github.com/PyProphet/pyprophet.git
+cd pyprophet
+git apply /data/manylinux.patch
+
+# Compile wheels
+for PYBIN in /opt/python/*27*/bin; do
+  "${PYBIN}/pip" install Cython
+  "${PYBIN}/pip" install numpy
+  "${PYBIN}/pip" install pandas
+  "${PYBIN}/pip" wheel . -w wheelhouse/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in wheelhouse/pyprophet*.whl; do
+    auditwheel repair "$whl" -w wheelhouse_final/
+done
+
+# upload / store result
+mv wheelhouse_final /data/
+## /opt/python/cp27-cp27mu/bin/pip install twine
+## /opt/python/cp27-cp27mu/bin/twine upload wheelhouse_final/* -u hroest
+
+

--- a/dist-scripts/manylinux.patch
+++ b/dist-scripts/manylinux.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index 23412c3..383f23d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -47,8 +47,7 @@ setup(name='pyprophet',
+           "scipy >= 0.9.0",
+           "numexpr >= 2.1",
+           "scikit-learn >= 0.17",
+-          "matplotlib",
+-          "seaborn"
++          "matplotlib == 1.5.3"
+       ],
+       entry_points={
+           'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ min_numpy_version = (1, 9, 0)
 try:
     import numpy
 except ImportError:
-    print "need at least numpy %d.%d.%d" % min_numpy_version
+    print ("need at least numpy %d.%d.%d" % min_numpy_version)
 else:
     vtuple = tuple(map(int, numpy.__version__.split(".")))
     msg = "need at least numpy %s, found %s" % (min_numpy_version, vtuple)


### PR DESCRIPTION
produce the following wheels:

```
$ sudo docker run --net=host -v `pwd`:/data quay.io/pypa/manylinux1_x86_64 /bin/bash /data/create-manylinux.sh
$ ls -ltrh wheelhouse/
total 2.0M
-rw-r--r-- 1 root root 406K Jul 26 14:50 pyprophet-0.24.1-cp27-cp27m-manylinux1_x86_64.whl
-rw-r--r-- 1 root root 406K Jul 26 14:50 pyprophet-0.24.1-cp27-cp27mu-manylinux1_x86_64.whl
-rw-r--r-- 1 root root 403K Jul 26 14:50 pyprophet-0.24.1-cp34-cp34m-manylinux1_x86_64.whl
-rw-r--r-- 1 root root 400K Jul 26 14:50 pyprophet-0.24.1-cp35-cp35m-manylinux1_x86_64.whl
-rw-r--r-- 1 root root 400K Jul 26 14:50 pyprophet-0.24.1-cp36-cp36m-manylinux1_x86_64.whl
```

this script makes wheels for Python 2.7, 3.4, 3.5 and 3.6 - since pandas does not work on 3.3 we cannot make wheels for that.