### PR TITLE
[FIX] Replace lfdr scipy interpolation function with FITPACK

### DIFF
--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -306,8 +306,8 @@ def lfdr(p_values, pi0, trunc = True, monotone = True, transf = "probit", adj = 
         bw = bw_nrd0(x)
         myd = KDEUnivariate(x)
         myd.fit(bw=adj*bw, gridsize = 512)
-        splinefit = sp.interpolate.make_interp_spline(myd.support, myd.density)
-        y = splinefit(x)
+        splinefit = sp.interpolate.splrep(myd.support, myd.density)
+        y = sp.interpolate.splev(x, splinefit)
         # myd = density(x, adjust = 1.5) # R reference function
         # mys = smoothspline(x = myd.rx2('x'), y = myd.rx2('y')) # R reference function
         # y = predict(mys, x).rx2('y') # R reference function
@@ -321,8 +321,8 @@ def lfdr(p_values, pi0, trunc = True, monotone = True, transf = "probit", adj = 
         myd = KDEUnivariate(x)
         myd.fit(bw=adj*bw, gridsize = 512)
 
-        splinefit = sp.interpolate.make_interp_spline(myd.support, myd.density)
-        y = splinefit(x)
+        splinefit = sp.interpolate.splrep(myd.support, myd.density)
+        y = sp.interpolate.splev(x, splinefit)
         # myd = density(x, adjust = 1.5) # R reference function
         # mys = smoothspline(x = myd.rx2('x'), y = myd.rx2('y')) # R reference function
         # y = predict(mys, x).rx2('y') # R reference function


### PR DESCRIPTION
This PR provides a workaround for issue B reported by @bretttully in https://github.com/PyProphet/pyprophet/issues/38.

In this case, the target and decoy protein score distributions are completely separate, resulting in monotonic p-values as estimated by the empirical p-value function, which are not compatible with the spline fitting method used in ``lfdr``. By replacing the function with a FITPACK wrapper, NAs are produced in this extreme case to indictate that the estimation of local FDR is not applicable.