### PR TITLE
[FIX] Backpropagation of peptide- or protein-only scores, part 2

### DIFF
--- a/pyprophet/levels_contexts.py
+++ b/pyprophet/levels_contexts.py
@@ -603,7 +603,7 @@ def backpropagate_oswr(infile, outfile, apply_scores):
         script.append(create_table_fmt.format('SCORE_PROTEIN'))
 
     # copy across the tables
-    script.append('ATTACH DATABASE "{apply_scores}" AS sdb;')
+    script.append('ATTACH DATABASE "{}" AS sdb;'.format(apply_scores))
     insert_table_fmt = 'INSERT INTO {0}\nSELECT *\nFROM sdb.{0};'
     if peptide_present:
         script.append(insert_table_fmt.format('SCORE_PEPTIDE'))


### PR DESCRIPTION
Addresses the new issue in #40 