### PR TITLE
[FEATURE] merge same run

### DIFF
--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -225,16 +225,17 @@ def reduce(infile, outfile):
 @cli.command()
 @click.argument('infiles', nargs=-1, type=click.Path(exists=True))
 @click.option('--out','outfile', required=True, type=click.Path(exists=False), help='Merged OSW output file.')
+@click.option('--same_run/--no-same_run', default=False, help='Assume input files are from same run (deletes run information).')
 @click.option('--template','templatefile', required=True, type=click.Path(exists=False), help='Template OSW file.')
-def merge(infiles, outfile, templatefile):
+def merge(infiles, outfile, same_run, templatefile):
     """
-    Merge multiple OSW files and optionally subsample the data for faster learning.
+    Merge multiple OSW files and (for large experiments, it is recommended to subsample first).
     """
 
     if len(infiles) < 1:
-        sys.exit("Error: At least one PyProphet input file needs to be defined.")
+        sys.exit("Error: At least one PyProphet input file needs to be provided.")
 
-    merge_osw(infiles, outfile, templatefile)
+    merge_osw(infiles, outfile, templatefile, same_run)
 
 
 # Backpropagate multi-run peptide and protein scores to single files


### PR DESCRIPTION
- allows merging of multiple files that come from the same mzML input
  file and need to be treated as such in subsequent analysis

We have some data in our lab where we are running overlapping windows and each mzML file produces 2 .osw files since we need to split the files and run them separately through OpenSWATH. This PR allows merging of the two files again but treating them as coming from the same original file. This is important because we may have duplicate entries (e.g. tr_gr_1 was extracted from both OpenSWATH runs but we want to score them together so that tr_gr_1 gets selected only once, either from osw_1 or from osw_2). I think this PR should allow that, any feedback?