### PR TITLE
[FIX] Better warnings & end of Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: xenial
 language: python
 python:
-  - "2.7"
+  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -20,10 +20,9 @@ install:
   - pip install -U numexpr
   - pip install -U statsmodels
   - pip install -U matplotlib
-  - pip install -U networkx==2.2
+  - pip install -U networkx
   - travis_retry python setup.py develop
 script: 
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then py.test tests/; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.4* ]]; then py.test tests/; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.5* ]]; then py.test tests/; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6* ]]; then py.test tests/; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# PyProphet Dockerfile
+FROM ubuntu:18.04
+
+# install base dependencies
+RUN apt-get -y update
+RUN apt-get install -y python3 python3-pip python3-numpy
+
+# patch Python
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# install PyProphet and dependencies
+ADD . /pyprophet
+WORKDIR /pyprophet
+RUN python3 setup.py install
+WORKDIR /
+RUN rm -rf /pyprophet

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SRM experiments.* **Nat Methods.** 2011 May;8(5):430-5. [doi:
 Installation
 ============
 
-We strongly advice to install PyProphet in a Python [*virtualenv*](https://virtualenv.pypa.io/en/stable/). PyProphet is compatible with Python 2.7 and provides experimental support for Python 3.
+We strongly advice to install PyProphet in a Python [*virtualenv*](https://virtualenv.pypa.io/en/stable/). PyProphet is compatible with Python 3.
 
 Install the development version of *pyprophet* from GitHub:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ or:
    $ pyprophet score --in=tests/test_data.txt
 ````
 
+Docker
+=================
+
+PyProphet is also available from Docker (automated builds:
+
+Pull the development version of *pyprophet* from DockerHub (synced with GitHub):
+
+````
+    $ docker pull pyprophet/master:latest
+````
+
+Pull the stable version (e.g. 2.1.2) of *pyprophet* from DockerHub (synced with releases):
+
+````
+    $ docker pull pyprophet/pyprophet:2.1.2
+````
 
 Running tests
 =============

--- a/pyprophet/runner.py
+++ b/pyprophet/runner.py
@@ -95,6 +95,8 @@ ORDER BY RUN_ID,
          FEATURE.EXP_RT ASC;
 ''', con)
             elif level == "transition":
+                if not check_sqlite_table(con, "SCORE_MS2"):
+                    raise click.ClickException("Transition-level scoring requires prior MS2 or MS1MS2-level scoring.")
                 if not check_sqlite_table(con, "FEATURE_TRANSITION"):
                     raise click.ClickException("Transition-level feature table not present in file.")
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pyprophet',
-      version="2.1.2dev1",
+      version="2.1.2",
       author="The PyProphet Developers",
       author_email="rocksportrocker@gmail.com",
       description="PyProphet: Semi-supervised learning and scoring of OpenSWATH results.",

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ ext_modules = [Extension("pyprophet._optimized", ["pyprophet/_optimized.c"])]
 # read the contents of README for PyPI
 from os import path
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md')) as f:
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pyprophet',
-      version="2.1.1",
+      version="2.1.2dev1",
       author="The PyProphet Developers",
       author_email="rocksportrocker@gmail.com",
       description="PyProphet: Semi-supervised learning and scoring of OpenSWATH results.",


### PR DESCRIPTION
This PR warns that transition-level scoring can only be conducted if MS1/MS2 scoring was conducted beforehand.

We should further consider removing support for Python 2, because many dependencies require workarounds which don't support Python 2 anymore. 