### PR TITLE
[FIX] merge osw with compounds 

### DIFF
--- a/pyprophet/levels_contexts.py
+++ b/pyprophet/levels_contexts.py
@@ -665,7 +665,12 @@ CREATE TABLE SCORE_MS2(FEATURE_ID INTEGER, SCORE REAL);
 
 CREATE TABLE FEATURE(ID INT PRIMARY KEY NOT NULL,
                      RUN_ID INT NOT NULL,
-                     PRECURSOR_ID INT NOT NULL);
+                     PRECURSOR_ID INT NOT NULL,
+                     EXP_RT REAL NULL,
+                     NORM_RT REAL NULL,
+                     DELTA_RT REAL NULL,
+                     LEFT_WIDTH REAL NULL,
+                     RIGHT_WIDTH REAL NULL);
 ''')
 
     for infile in infiles:


### PR DESCRIPTION
I had issues merging compound osw. 

This seems to be due to an updated format of the FEATURE Table in the .osw file using the "merge_oswr" function in "levels_contexts.py". 

`pyprophet merge --template "assay_library_t3_decoy.pqp" --out "merged_exp.osw" *.osw`

```
File "/usr/local/miniconda3/envs/py37/lib/python3.7/site-packages/pyprophet/levels_contexts.py", line 683, in merge_oswr
    c.executescript('ATTACH DATABASE "%s" AS sdb; INSERT INTO FEATURE SELECT * FROM sdb.FEATURE; DETACH DATABASE sdb;' % infile)
sqlite3.OperationalError: table FEATURE has 3 columns but 8 values were supplied
```
```
ID - RUN_ID - PRECURSOR_ID
vs 
ID - RUN_ID - PRECURSOR_ID - EXP_RT - NORM_RT - DELTA_RT - LEFT_WIDTH - RIGHT_WIDTH
```

I added them for table creation as "NULL" - please let me know if you think that breaks the compatibility and should be handled in another way. 

Thank you! 