### PR TITLE
[ADD] Add pi0estimation extended error help into separate PR from PR …

### DIFF
--- a/pyprophet/report.py
+++ b/pyprophet/report.py
@@ -138,3 +138,12 @@ def plot_scores(df, out, color_palette="normal"):
 
                 pdf.savefig()
                 plt.close()
+
+def plot_hist(x, title, xlabel, ylabel, pdf_path="histogram_plot.png"):
+
+    if plt is not None:
+        counts, __, __ = plt.hist(x, bins=20, density=True)
+        plt.title(title, wrap=True)
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        plt.savefig(pdf_path)

--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -11,6 +11,7 @@ import click
 
 from .optimized import (find_nearest_matches as _find_nearest_matches,
                        count_num_positives, single_chromatogram_hypothesis_fast)
+from .report import plot_hist
 from statsmodels.nonparametric.kde import KDEUnivariate
 from collections import namedtuple
 # from .config import CONFIG
@@ -224,7 +225,8 @@ def pi0est(p_values, lambda_ = np.arange(0.05,1.0,0.05), pi0_method = "smoother"
         else:
             raise click.ClickException("pi0_method must be one of 'smoother' or 'bootstrap'.")
     if (pi0<=0):
-        raise click.ClickException("The estimated pi0 <= 0. Check that you have valid p-values or use a different range of lambda.")
+        plot_hist(p, f"p-value density histogram used during pi0 estimation", "p-value", "density histogram", "pi0_estimation_error_pvalue_histogram_plot.pdf")
+        raise click.ClickException(f"The estimated pi0 <= 0. Check that you have valid p-values or use a different range of lambda. Current lambda range: {lambda_}")
 
     return {'pi0': pi0, 'pi0_lambda': pi0_lambda, 'lambda_': lambda_, 'pi0_smooth': pi0Smooth}
 


### PR DESCRIPTION
Separate pi0 estimation extended error help into separate PR from PR #101

# Report and Message when pi0 Estimation fails

I extended the error messaged when the estimated pi0 <= 0, to show what the current lambda values were used. I also included a report pdf of the pvalue histogram used in the pi0 estimation, to give the user a better idea of why it may have failed.

Error: The estimated pi0 <= 0. Check that you have valid p-values or use a different range of lambda. Current lambda: [0.1  0.15 0.2  0.25 0.3  0.35 0.4  0.45 0.5  0.55 0.6  0.65 0.7  0.75
 0.8  0.85 0.9  0.95]

## Example

![image](https://user-images.githubusercontent.com/32938975/156655495-2bac101d-7b3e-4be5-8c83-05e56db1f4f8.png)
