### PR TITLE
[MINOR] Docker file end bind mount point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,6 @@ WORKDIR /pyprophet
 RUN python setup.py install
 WORKDIR /
 RUN rm -rf /pyprophet
+
+# Set final working directory, useful for when binding to a local mount
+WORKDIR /data/


### PR DESCRIPTION
I added a final working directory (**/data/**) in the Dockerfile, because I found that when using the `click.argument` parser to collect files based on wild glob expansion (i.e. ***.sqMass**), I would get an error on failing to find the path to files when calling pyprophet from docker. So I explicitly set the end working directory of the docker image to **/data/** in the Dockerfile, and then bind the local directory to **/data/** when running from docker.

```
docker run -it --rm -v $PWD:/data/ pyprophet/pyprophet:2.1.10 pyprophet filter --in /data/merged.osw  *.sqMass
Usage: pyprophet filter [OPTIONS] [SQMASSFILES]...
Try 'pyprophet filter --help' for help.

Error: Invalid value for '[SQMASSFILES]...': Path 'test.sqMass' does not exist.
```