### PR TITLE
Feature/dynamic main score

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,6 @@ WORKDIR /pyprophet
 RUN python setup.py install
 WORKDIR /
 RUN rm -rf /pyprophet
+
+# Set final working directory, useful for when binding to a local mount
+WORKDIR /data/

--- a/pyprophet/classifiers.py
+++ b/pyprophet/classifiers.py
@@ -108,7 +108,7 @@ class XGBLearner(AbstractLearner):
                 'scale_pos_weight': "{:.3f}".format(params['scale_pos_weight']),
             }
             
-            clf = xgb.XGBClassifier(random_state=42, silent=1, objective='binary:logitraw', eval_metric='auc', **params)
+            clf = xgb.XGBClassifier(random_state=42, verbosity=0, objective='binary:logitraw', eval_metric='auc', **params)
 
             score = cross_val_score(clf, X, y, scoring='roc_auc', n_jobs=self.threads, cv=KFold(n_splits=3, shuffle=True, random_state=np.random.RandomState(42))).mean()
             # click.echo("Info: AUC: {:.3f} hyperparameters: {}".format(score, params))

--- a/pyprophet/data_handling.py
+++ b/pyprophet/data_handling.py
@@ -270,7 +270,7 @@ def update_chosen_main_score_in_table(train, score_columns, use_as_main_score):
     # Re-order main_score column index
     temp_col = train.df.pop('main_score')
     train.df.insert(5, temp_col.name, temp_col)
-    click.echo(f"INFO: Updated main score column from {old_main_score_column} to {use_as_main_score}...")
+    click.echo(f"Info: Updated main score column from {old_main_score_column} to {use_as_main_score}...")
     return train, tuple(updated_score_columns)
 class Experiment(object):
 

--- a/pyprophet/data_handling.py
+++ b/pyprophet/data_handling.py
@@ -246,7 +246,32 @@ def prepare_data_table(table,
     df = cleanup_and_check(df)
     return df, all_score_columns
 
-
+def update_chosen_main_score_in_table(train, score_columns, use_as_main_score):
+    """
+    Update feature tables main_score
+    """
+    # Get current main score column name
+    old_main_score_column = [col for col in score_columns if  'main' in col][0]
+    # Get tables aliased score variable name
+    df_column_score_alias = [col for col in train.df.columns if col not in ['tg_id', 'tg_num_id', 'is_decoy', 'is_top_peak', 'is_train', 'classifier_score']]
+    # Generate mapping to rename columns in table
+    mapper = {alias_col : col for alias_col, col in zip(df_column_score_alias, score_columns)}
+    # Rename columns with actual feature score names
+    train.df.rename(columns=mapper, inplace=True)
+    # Update coulmns to set new main score column based on most important feature column
+    updated_score_columns = [col.replace("main_", "") if col==old_main_score_column else col for col in score_columns]
+    updated_score_columns = [col.replace("var", "main_var") if col==use_as_main_score else col for col in updated_score_columns]
+    updated_score_columns = sorted(updated_score_columns, key=lambda x:(x!=use_as_main_score.replace("var", "main_var"), x))
+    updated_score_columns = [old_main_score_column if old_main_score_column.replace("main_", "")==col else col for col in updated_score_columns]
+    # Rename columns with feature aliases
+    mapper = {v : 'var_{0}'.format(i) for i, v in enumerate(updated_score_columns[1:len(updated_score_columns)])}
+    mapper[updated_score_columns[0].replace("main_", "")] = 'main_score' 
+    train.df.rename(columns=mapper, inplace=True)
+    # Re-order main_score column index
+    temp_col = train.df.pop('main_score')
+    train.df.insert(5, temp_col.name, temp_col)
+    click.echo(f"INFO: Updated main score column from {old_main_score_column} to {use_as_main_score}...")
+    return train, tuple(updated_score_columns)
 class Experiment(object):
 
     @profile

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -73,10 +73,11 @@ def cli():
 @click.option('--tric_chromprob/--no-tric_chromprob', default=False, show_default=True, help='Whether chromatogram probabilities for TRIC should be computed.')
 # Visualization
 @click.option('--color_palette', default='normal', show_default=True, type=click.Choice(['normal', 'protan', 'deutran', 'tritan']), help='Color palette to use in reports.')
+@click.option('--main_score_selection_report/--no-main_score_selection_report', default=False, show_default=True, help='Generate a report for main score selection process.')
 # Processing
 @click.option('--threads', default=1, show_default=True, type=int, help='Number of threads used for semi-supervised learning. -1 means all available CPUs.', callback=transform_threads)
 @click.option('--test/--no-test', default=False, show_default=True, help='Run in test mode with fixed seed.')
-def score(infile, outfile, classifier, xgb_autotune, apply_weights, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette):
+def score(infile, outfile, classifier, xgb_autotune, apply_weights, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette, main_score_selection_report):
     """
     Conduct semi-supervised learning and error-rate estimation for MS1, MS2 and transition-level data. 
     """
@@ -94,7 +95,7 @@ def score(infile, outfile, classifier, xgb_autotune, apply_weights, xeval_fracti
     xgb_params_space = {'eta': hp.uniform('eta', 0.0, 0.3), 'gamma': hp.uniform('gamma', 0.0, 0.5), 'max_depth': hp.quniform('max_depth', 2, 8, 1), 'min_child_weight': hp.quniform('min_child_weight', 1, 5, 1), 'subsample': 1, 'colsample_bytree': 1, 'colsample_bylevel': 1, 'colsample_bynode': 1, 'lambda': hp.uniform('lambda', 0.0, 1.0), 'alpha': hp.uniform('alpha', 0.0, 1.0), 'scale_pos_weight': 1.0, 'verbosity': 0, 'objective': 'binary:logitraw', 'nthread': 1, 'eval_metric': 'auc'}
 
     if not apply_weights:
-        PyProphetLearner(infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette).run()
+        PyProphetLearner(infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette, main_score_selection_report).run()
     else:
         
         PyProphetWeightApplier(infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, apply_weights, ss_score_filter, color_palette).run()

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -89,13 +89,14 @@ def score(infile, outfile, classifier, xgb_autotune, apply_weights, xeval_fracti
     # Prepare XGBoost-specific parameters
     xgb_hyperparams = {'autotune': xgb_autotune, 'autotune_num_rounds': 10, 'num_boost_round': 100, 'early_stopping_rounds': 10, 'test_size': 0.33}
 
-    xgb_params = {'eta': 0.3, 'gamma': 0, 'max_depth': 6, 'min_child_weight': 1, 'subsample': 1, 'colsample_bytree': 1, 'colsample_bylevel': 1, 'colsample_bynode': 1, 'lambda': 1, 'alpha': 0, 'scale_pos_weight': 1, 'silent': 1, 'objective': 'binary:logitraw', 'nthread': 1, 'eval_metric': 'auc'}
+    xgb_params = {'eta': 0.3, 'gamma': 0, 'max_depth': 6, 'min_child_weight': 1, 'subsample': 1, 'colsample_bytree': 1, 'colsample_bylevel': 1, 'colsample_bynode': 1, 'lambda': 1, 'alpha': 0, 'scale_pos_weight': 1, 'verbosity': 0, 'objective': 'binary:logitraw', 'nthread': 1, 'eval_metric': 'auc'}
 
-    xgb_params_space = {'eta': hp.uniform('eta', 0.0, 0.3), 'gamma': hp.uniform('gamma', 0.0, 0.5), 'max_depth': hp.quniform('max_depth', 2, 8, 1), 'min_child_weight': hp.quniform('min_child_weight', 1, 5, 1), 'subsample': 1, 'colsample_bytree': 1, 'colsample_bylevel': 1, 'colsample_bynode': 1, 'lambda': hp.uniform('lambda', 0.0, 1.0), 'alpha': hp.uniform('alpha', 0.0, 1.0), 'scale_pos_weight': 1.0, 'silent': 1, 'objective': 'binary:logitraw', 'nthread': 1, 'eval_metric': 'auc'}
+    xgb_params_space = {'eta': hp.uniform('eta', 0.0, 0.3), 'gamma': hp.uniform('gamma', 0.0, 0.5), 'max_depth': hp.quniform('max_depth', 2, 8, 1), 'min_child_weight': hp.quniform('min_child_weight', 1, 5, 1), 'subsample': 1, 'colsample_bytree': 1, 'colsample_bylevel': 1, 'colsample_bynode': 1, 'lambda': hp.uniform('lambda', 0.0, 1.0), 'alpha': hp.uniform('alpha', 0.0, 1.0), 'scale_pos_weight': 1.0, 'verbosity': 0, 'objective': 'binary:logitraw', 'nthread': 1, 'eval_metric': 'auc'}
 
     if not apply_weights:
         PyProphetLearner(infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette).run()
     else:
+        
         PyProphetWeightApplier(infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, apply_weights, ss_score_filter, color_palette).run()
 
 

--- a/pyprophet/pyprophet.py
+++ b/pyprophet/pyprophet.py
@@ -264,11 +264,11 @@ class HolyGostQuery(object):
     def _learn_and_apply(self, table):
 
         experiment, score_columns = self._setup_experiment(table)
-        final_classifier = self._learn(experiment)
+        final_classifier = self._learn(experiment, score_columns)
 
         return self._build_result(table, final_classifier, score_columns, experiment)
 
-    def _learn(self, experiment):
+    def _learn(self, experiment, score_columns):
         if self.test:  # for reliable results
             experiment.df.sort_values("tg_id", ascending=True, inplace=True)
 
@@ -285,7 +285,7 @@ class HolyGostQuery(object):
 
         if self.threads == 1:
             for k in range(neval):
-                (ttt_scores, ttd_scores, w) = learner.learn_randomized(experiment)
+                (ttt_scores, ttd_scores, w) = learner.learn_randomized(experiment, score_columns)
                 ttt.append(ttt_scores)
                 ttd.append(ttd_scores)
                 ws.append(w)
@@ -295,7 +295,7 @@ class HolyGostQuery(object):
                 remaining = max(0, neval - self.threads)
                 todo = neval - remaining
                 neval -= todo
-                args = ((learner, "learn_randomized", (experiment, )), ) * todo
+                args = ((learner, "learn_randomized", (experiment, score_columns, )), ) * todo
                 res = pool.map(unwrap_self_for_multiprocessing, args)
                 ttt_scores = [r[0] for r in res]
                 ttd_scores = [r[1] for r in res]

--- a/pyprophet/pyprophet.py
+++ b/pyprophet/pyprophet.py
@@ -285,7 +285,7 @@ class HolyGostQuery(object):
 
         if self.threads == 1:
             for k in range(neval):
-                (ttt_scores, ttd_scores, w) = learner.learn_randomized(experiment, score_columns)
+                (ttt_scores, ttd_scores, w) = learner.learn_randomized(experiment, score_columns, 1)
                 ttt.append(ttt_scores)
                 ttd.append(ttd_scores)
                 ws.append(w)
@@ -295,7 +295,12 @@ class HolyGostQuery(object):
                 remaining = max(0, neval - self.threads)
                 todo = neval - remaining
                 neval -= todo
-                args = ((learner, "learn_randomized", (experiment, score_columns, )), ) * todo
+                # args = ((learner, "learn_randomized", (experiment, score_columns, )), ) * todo
+                # Add individual worker ids
+                args = []
+                for thread_num in range(1, todo+1):
+                    args.append((learner, "learn_randomized", (experiment, score_columns, thread_num, )))
+                args = tuple(args)
                 res = pool.map(unwrap_self_for_multiprocessing, args)
                 ttt_scores = [r[0] for r in res]
                 ttd_scores = [r[1] for r in res]
@@ -347,10 +352,10 @@ class HolyGostQuery(object):
 
 
 @profile
-def PyProphet(classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette):
+def PyProphet(classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette, main_score_selection_report, outfile, level):
     if classifier == "LDA":
-        return HolyGostQuery(StandardSemiSupervisedLearner(LDALearner(), xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test), classifier, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette)
+        return HolyGostQuery(StandardSemiSupervisedLearner(LDALearner(), xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test, main_score_selection_report, outfile, level), classifier, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette)
     elif classifier == "XGBoost":
-        return HolyGostQuery(StandardSemiSupervisedLearner(XGBLearner(xgb_hyperparams, xgb_params, xgb_params_space, threads), xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test), classifier, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette)
+        return HolyGostQuery(StandardSemiSupervisedLearner(XGBLearner(xgb_hyperparams, xgb_params, xgb_params_space, threads), xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test, main_score_selection_report, outfile, level), classifier, ss_num_iter, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, tric_chromprob, threads, test, ss_score_filter, color_palette)
     else:
         raise click.ClickException("Classifier not supported.")

--- a/pyprophet/runner.py
+++ b/pyprophet/runner.py
@@ -28,7 +28,7 @@ class PyProphetRunner(object):
     """Base class for workflow of command line tool
     """
 
-    def __init__(self, infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette):
+    def __init__(self, infile, outfile, classifier, xgb_hyperparams, xgb_params, xgb_params_space, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, ss_num_iter, ss_main_score, group_id, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, lfdr_truncate, lfdr_monotone, lfdr_transformation, lfdr_adj, lfdr_eps, level, ipf_max_peakgroup_rank, ipf_max_peakgroup_pep, ipf_max_transition_isotope_overlap, ipf_min_transition_sn, tric_chromprob, threads, test, ss_score_filter, color_palette, main_score_selection_report):
         def read_tsv(infile):
             table = pd.read_csv(infile, "\t")
             return(table)
@@ -232,6 +232,7 @@ ORDER BY RUN_ID,
         self.test = test
         self.ss_score_filter = ss_score_filter
         self.color_palette = color_palette
+        self.main_score_selection_report = main_score_selection_report
 
         self.prefix = os.path.splitext(outfile)[0]
 
@@ -414,7 +415,7 @@ ORDER BY RUN_ID,
 class PyProphetLearner(PyProphetRunner):
 
     def run_algo(self):
-        (result, scorer, weights) = PyProphet(self.classifier, self.xgb_hyperparams, self.xgb_params, self.xgb_params_space, self.xeval_fraction, self.xeval_num_iter, self.ss_initial_fdr, self.ss_iteration_fdr, self.ss_num_iter, self.group_id, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0, self.lfdr_truncate, self.lfdr_monotone, self.lfdr_transformation, self.lfdr_adj, self.lfdr_eps, self.tric_chromprob, self.threads, self.test, self.ss_score_filter, self.color_palette).learn_and_apply(self.table)
+        (result, scorer, weights) = PyProphet(self.classifier, self.xgb_hyperparams, self.xgb_params, self.xgb_params_space, self.xeval_fraction, self.xeval_num_iter, self.ss_initial_fdr, self.ss_iteration_fdr, self.ss_num_iter, self.group_id, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0, self.lfdr_truncate, self.lfdr_monotone, self.lfdr_transformation, self.lfdr_adj, self.lfdr_eps, self.tric_chromprob, self.threads, self.test, self.ss_score_filter, self.color_palette, self.main_score_selection_report, self.outfile, self.level).learn_and_apply(self.table)
         return (result, scorer, weights)
 
     def extra_writes(self):

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -175,8 +175,12 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         return w, clf_scores, mapper[use_as_main_col_alias]
 
     @profile
-    def iter_semi_supervised_learning(self, train):
-        td_peaks, bt_peaks = self.select_train_peaks(train, "classifier_score", self.ss_iteration_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
+    def iter_semi_supervised_learning(self, train, score_columns, working_thread_number):
+        # Get tables aliased score variable name
+        df_column_score_alias = [col for col in train.df.columns if col not in ['tg_id', 'tg_num_id', 'is_decoy', 'is_top_peak', 'is_train']]
+        # Generate column alias name to score feature name
+        mapper = {alias_col : col for alias_col, col in zip(df_column_score_alias, score_columns + ('classifier_score',))}
+        td_peaks, bt_peaks = self.select_train_peaks(train, "classifier_score", self.ss_iteration_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0, mapper, self.main_score_selection_report, self.outfile, self.level, working_thread_number)
 
         model = self.inner_learner.learn(td_peaks, bt_peaks, True)
         w = model.get_parameters()

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -4,7 +4,7 @@ import click
 from .data_handling import Experiment, update_chosen_main_score_in_table
 from .classifiers import AbstractLearner, XGBLearner
 from .stats import mean_and_std_dev, find_cutoff
-import code
+
 try:
     profile
 except NameError:

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -59,7 +59,7 @@ class AbstractSemiSupervisedLearner(object):
             # if inner == 0:
             #     params, clf_scores = self.tune_semi_supervised_learning(train)
             # else:
-            params, clf_scores = self.iter_semi_supervised_learning(train)
+            params, clf_scores = self.iter_semi_supervised_learning(train, score_columns, working_thread_number)
             train.set_and_rerank("classifier_score", clf_scores)
 
         # after semi supervised iteration: classify full dataset
@@ -166,7 +166,7 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         else:
             use_as_main_col_alias = 'main_score'
 
-        td_peaks, bt_peaks = self.select_train_peaks(train, use_as_main_col_alias, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
+        td_peaks, bt_peaks = self.select_train_peaks(train, use_as_main_col_alias, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0, mapper, self.main_score_selection_report, self.outfile, self.level, working_thread_number)
         model = self.inner_learner.learn(td_peaks, bt_peaks, False)
         w = model.get_parameters()
         clf_scores = model.score(train, False)

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -154,8 +154,12 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         # Get tables aliased score variable name
         df_column_score_alias = [col for col in train.df.columns if col not in ['tg_id', 'tg_num_id', 'is_decoy', 'is_top_peak', 'is_train', 'classifier_score']]
 
-        # Use the min() function to find the column with the smallest delta value
-        use_as_main_col_alias = min(df_column_score_alias, key=lambda x: self.get_delta_td_bt_feature_size(train, x))
+        if isinstance(self.inner_learner, XGBLearner):
+            # dynamic selection of main score seems to only benefit the XBGLearner, the LDALearner performs worse when we apply this
+            # Use the min() function to find the column with the smallest delta value
+            use_as_main_col_alias = min(df_column_score_alias, key=lambda x: self.get_delta_td_bt_feature_size(train, x))
+        else:
+            use_as_main_col_alias = 'main_score'
 
         td_peaks, bt_peaks = self.select_train_peaks(train, use_as_main_col_alias, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
         model = self.inner_learner.learn(td_peaks, bt_peaks, False)

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -4,7 +4,7 @@ import click
 from .data_handling import Experiment, update_chosen_main_score_in_table
 from .classifiers import AbstractLearner, XGBLearner
 from .stats import mean_and_std_dev, find_cutoff
-
+import code
 try:
     profile
 except NameError:
@@ -18,7 +18,7 @@ class AbstractSemiSupervisedLearner(object):
         self.xeval_num_iter = xeval_num_iter
         self.test = test
 
-    def start_semi_supervised_learning(self, train, score_columns):
+    def start_semi_supervised_learning(self, train, score_columns, working_thread_number):
         raise NotImplementedError()
 
     def iter_semi_supervised_learning(self, train):
@@ -31,7 +31,7 @@ class AbstractSemiSupervisedLearner(object):
         raise NotImplementedError()
 
     @profile
-    def learn_randomized(self, experiment, score_columns):
+    def learn_randomized(self, experiment, score_columns, working_thread_number):
         assert isinstance(experiment, Experiment)
 
         click.echo("Info: Learning on cross-validation fold.")
@@ -41,7 +41,7 @@ class AbstractSemiSupervisedLearner(object):
 
         train.rank_by("main_score")
 
-        params, clf_scores, use_as_main_score = self.start_semi_supervised_learning(train, score_columns)
+        params, clf_scores, use_as_main_score = self.start_semi_supervised_learning(train, score_columns, working_thread_number)
         
         # Get current main score column name
         old_main_score_column = [col for col in score_columns if  'main' in col][0]
@@ -106,7 +106,7 @@ class AbstractSemiSupervisedLearner(object):
 
 class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
 
-    def __init__(self, inner_learner, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test):
+    def __init__(self, inner_learner, xeval_fraction, xeval_num_iter, ss_initial_fdr, ss_iteration_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, test, main_score_selection_report, outfile, level):
         assert isinstance(inner_learner, AbstractLearner)
         AbstractSemiSupervisedLearner.__init__(self, xeval_fraction, xeval_num_iter, test)
         self.inner_learner = inner_learner
@@ -120,8 +120,11 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         self.pi0_method = pi0_method
         self.pi0_smooth_df = pi0_smooth_df
         self.pi0_smooth_log_pi0 = pi0_smooth_log_pi0
+        self.main_score_selection_report = main_score_selection_report
+        self.outfile = outfile
+        self.level = level
 
-    def select_train_peaks(self, train, sel_column, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0):
+    def select_train_peaks(self, train, sel_column, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, mapper=None, main_score_selection_report=None, outfile=None, level=None, working_thread_number=None):
         assert isinstance(train, Experiment)
         assert isinstance(sel_column, str)
         assert isinstance(cutoff_fdr, float)
@@ -132,32 +135,34 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         td_scores = td_peaks[sel_column]
 
         # find cutoff fdr from scores and only use best target peaks:
-        cutoff = find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)
+        cutoff = find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, sel_column, mapper, main_score_selection_report, outfile, level, working_thread_number)
         best_target_peaks = tt_peaks.filter_(tt_scores >= cutoff)
         return td_peaks, best_target_peaks
 
-    def get_delta_td_bt_feature_size(self, train, col):
+    def get_delta_td_bt_feature_size(self, train, col, mapper, working_thread_number):
         '''
         Get the the difference in feature size based on which column is used in select_train_peaks for top decoy features and best target features
         '''
         assert isinstance(train, Experiment)
         assert isinstance(col, str)
+        
         # Try catch exception when using a feature column that cannot generate a valid pi0 estimation due to imbalance of number of top decoys to best targets
         try:
-            td_peaks, bt_peaks = self.select_train_peaks(train, col, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
+            td_peaks, bt_peaks = self.select_train_peaks(train, col, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0, mapper, self.main_score_selection_report, self.outfile, self.level, working_thread_number)
             return abs(td_peaks.df.shape[0] - bt_peaks.df.shape[0])
         except:
             # Return highest possible value if select_train_peaks fails to run due to not being able to compute pi0 estimation
             return float('inf')
 
-    def start_semi_supervised_learning(self, train, score_columns):
+    def start_semi_supervised_learning(self, train, score_columns, working_thread_number):
         # Get tables aliased score variable name
         df_column_score_alias = [col for col in train.df.columns if col not in ['tg_id', 'tg_num_id', 'is_decoy', 'is_top_peak', 'is_train', 'classifier_score']]
-
+        # Generate column alias name to score feature name
+        mapper = {alias_col : col for alias_col, col in zip(df_column_score_alias, score_columns)}
         if isinstance(self.inner_learner, XGBLearner):
             # dynamic selection of main score seems to only benefit the XBGLearner, the LDALearner performs worse when we apply this
             # Use the min() function to find the column with the smallest delta value
-            use_as_main_col_alias = min(df_column_score_alias, key=lambda x: self.get_delta_td_bt_feature_size(train, x))
+            use_as_main_col_alias = min(df_column_score_alias, key=lambda x: self.get_delta_td_bt_feature_size(train, x, mapper, working_thread_number))
         else:
             use_as_main_col_alias = 'main_score'
 
@@ -166,8 +171,6 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         w = model.get_parameters()
         clf_scores = model.score(train, False)
         clf_scores -= np.mean(clf_scores)
-
-        mapper = {alias_col : col for alias_col, col in zip(df_column_score_alias, score_columns)}
 
         return w, clf_scores, mapper[use_as_main_col_alias]
 

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -124,7 +124,7 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         self.outfile = outfile
         self.level = level
 
-    def select_train_peaks(self, train, sel_column, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, mapper=None, main_score_selection_report=None, outfile=None, level=None, working_thread_number=None):
+    def select_train_peaks(self, train, sel_column, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, mapper=None, main_score_selection_report=False, outfile=None, level=None, working_thread_number=None):
         assert isinstance(train, Experiment)
         assert isinstance(sel_column, str)
         assert isinstance(cutoff_fdr, float)

--- a/pyprophet/semi_supervised.py
+++ b/pyprophet/semi_supervised.py
@@ -1,7 +1,7 @@
 import numpy as np
 import click
 
-from .data_handling import Experiment
+from .data_handling import Experiment, update_chosen_main_score_in_table
 from .classifiers import AbstractLearner, XGBLearner
 from .stats import mean_and_std_dev, find_cutoff
 
@@ -18,7 +18,7 @@ class AbstractSemiSupervisedLearner(object):
         self.xeval_num_iter = xeval_num_iter
         self.test = test
 
-    def start_semi_supervised_learning(self, train):
+    def start_semi_supervised_learning(self, train, score_columns):
         raise NotImplementedError()
 
     def iter_semi_supervised_learning(self, train):
@@ -31,7 +31,7 @@ class AbstractSemiSupervisedLearner(object):
         raise NotImplementedError()
 
     @profile
-    def learn_randomized(self, experiment):
+    def learn_randomized(self, experiment, score_columns):
         assert isinstance(experiment, Experiment)
 
         click.echo("Info: Learning on cross-validation fold.")
@@ -41,7 +41,15 @@ class AbstractSemiSupervisedLearner(object):
 
         train.rank_by("main_score")
 
-        params, clf_scores = self.start_semi_supervised_learning(train)
+        params, clf_scores, use_as_main_score = self.start_semi_supervised_learning(train, score_columns)
+        
+        # Get current main score column name
+        old_main_score_column = [col for col in score_columns if  'main' in col][0]
+        # Only Update if chosen main score column has changed
+        if use_as_main_score != old_main_score_column:
+            train, _ = update_chosen_main_score_in_table(train, score_columns, use_as_main_score)
+            train.rank_by("main_score")
+            experiment, score_columns = update_chosen_main_score_in_table(experiment, score_columns, use_as_main_score)
 
         train.set_and_rerank("classifier_score", clf_scores)
 
@@ -128,13 +136,36 @@ class StandardSemiSupervisedLearner(AbstractSemiSupervisedLearner):
         best_target_peaks = tt_peaks.filter_(tt_scores >= cutoff)
         return td_peaks, best_target_peaks
 
-    def start_semi_supervised_learning(self, train):
-        td_peaks, bt_peaks = self.select_train_peaks(train, "main_score", self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
+    def get_delta_td_bt_feature_size(self, train, col):
+        '''
+        Get the the difference in feature size based on which column is used in select_train_peaks for top decoy features and best target features
+        '''
+        assert isinstance(train, Experiment)
+        assert isinstance(col, str)
+        # Try catch exception when using a feature column that cannot generate a valid pi0 estimation due to imbalance of number of top decoys to best targets
+        try:
+            td_peaks, bt_peaks = self.select_train_peaks(train, col, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
+            return abs(td_peaks.df.shape[0] - bt_peaks.df.shape[0])
+        except:
+            # Return highest possible value if select_train_peaks fails to run due to not being able to compute pi0 estimation
+            return float('inf')
+
+    def start_semi_supervised_learning(self, train, score_columns):
+        # Get tables aliased score variable name
+        df_column_score_alias = [col for col in train.df.columns if col not in ['tg_id', 'tg_num_id', 'is_decoy', 'is_top_peak', 'is_train', 'classifier_score']]
+
+        # Use the min() function to find the column with the smallest delta value
+        use_as_main_col_alias = min(df_column_score_alias, key=lambda x: self.get_delta_td_bt_feature_size(train, x))
+
+        td_peaks, bt_peaks = self.select_train_peaks(train, use_as_main_col_alias, self.ss_initial_fdr, self.parametric, self.pfdr, self.pi0_lambda, self.pi0_method, self.pi0_smooth_df, self.pi0_smooth_log_pi0)
         model = self.inner_learner.learn(td_peaks, bt_peaks, False)
         w = model.get_parameters()
         clf_scores = model.score(train, False)
         clf_scores -= np.mean(clf_scores)
-        return w, clf_scores
+
+        mapper = {alias_col : col for alias_col, col in zip(df_column_score_alias, score_columns)}
+
+        return w, clf_scores, mapper[use_as_main_col_alias]
 
     @profile
     def iter_semi_supervised_learning(self, train):

--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -459,10 +459,13 @@ def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, 
         try:
             # estimate pi0
             pi0 = pi0est(target_pvalues, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)
-        except:
+        except Exception as e:
             pi0 = None
+            pi0_error_msg = e
         # generate main score selection report
-        main_score_selection_report(title, sel_column, mapper, decoy_scores, target_scores, target_pvalues, pi0, pdf_path=os.path.join(os.path.dirname(title), f"main_score_selection_{level}_report_thread_{working_thread_number}.pdf"), worker_num=working_thread_number)
+        main_score_selection_report(os.path.basename(title), sel_column, mapper, decoy_scores, target_scores, target_pvalues, pi0, pdf_path=os.path.join(os.path.dirname(title), os.path.splitext(os.path.basename(title))[0] + f"_main_score_selection_{level}_report_thread_{working_thread_number}.pdf"), worker_num=working_thread_number)
+        if pi0 is None:
+            raise click.ClickException(f"{pi0_error_msg}")
     else:
         # estimate pi0
         pi0 = pi0est(target_pvalues, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)

--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -8,10 +8,11 @@ import scipy.stats
 import scipy.special
 import multiprocessing
 import click
+import os
 
 from .optimized import (find_nearest_matches as _find_nearest_matches,
                        count_num_positives, single_chromatogram_hypothesis_fast)
-from .report import plot_hist
+from .report import plot_hist, main_score_selection_report
 from statsmodels.nonparametric.kde import KDEUnivariate
 from collections import namedtuple
 # from .config import CONFIG
@@ -41,7 +42,7 @@ def find_nearest_matches(x, y):
 
 def to_one_dim_array(values, as_type=None):
     """ Converts list or flattens n-dim array to 1-dim array if possible """
-
+    
     if isinstance(values, (list, tuple)):
         values = np.array(values, dtype=np.float32)
     elif isinstance(values, pd.Series):
@@ -133,48 +134,48 @@ def pnorm(stat, stat0):
 
 def pemp(stat, stat0):
     """ Computes empirical values identically to bioconductor/qvalue empPvals """
-
+    
     assert len(stat0) > 0
     assert len(stat) > 0
-
+    
     stat = np.array(stat)
     stat0 = np.array(stat0)
-
+    
     m = len(stat)
     m0 = len(stat0)
-
+    
     statc = np.concatenate((stat, stat0))
     v = np.array([True] * m + [False] * m0)
     perm = np.argsort(-statc, kind="mergesort")  # reversed sort, mergesort is stable
     v = v[perm]
-
+    
     u = np.where(v)[0]
     p = (u - np.arange(m)) / float(m0)
-
+    
     # ranks can be fractional, we round down to the next integer, ranking returns values starting
     # with 1, not 0:
     ranks = np.floor(scipy.stats.rankdata(-stat)).astype(int) - 1
     p = p[ranks]
     p[p <= 1.0 / m0] = 1.0 / m0
-
+    
     return p
 
 
 @profile
 def pi0est(p_values, lambda_ = np.arange(0.05,1.0,0.05), pi0_method = "smoother", smooth_df = 3, smooth_log_pi0 = False):
     """ Estimate pi0 according to bioconductor/qvalue """
-
+    
     # Compare to bioconductor/qvalue reference implementation
     # import rpy2
     # import rpy2.robjects as robjects
     # from rpy2.robjects import pandas2ri
     # pandas2ri.activate()
-
+    
     # smoothspline=robjects.r('smooth.spline')
     # predict=robjects.r('predict')
-
+    
     p = np.array(p_values)
-
+    
     rm_na = np.isfinite(p)
     p = p[rm_na]
     m = len(p)
@@ -182,14 +183,14 @@ def pi0est(p_values, lambda_ = np.arange(0.05,1.0,0.05), pi0_method = "smoother"
     if isinstance(lambda_, np.ndarray ):
         ll = len(lambda_)
         lambda_ = np.sort(lambda_)
-
+    
     if (min(p) < 0 or max(p) > 1):
         raise click.ClickException("p-values not in valid range [0,1].")
     elif (ll > 1 and ll < 4):
         raise click.ClickException("If lambda_ is not predefined (one value), at least four data points are required.")
     elif (np.min(lambda_) < 0 or np.max(lambda_) >= 1):
         raise click.ClickException("Lambda must be within [0,1)")
-
+    
     if (ll == 1):
         pi0 = np.mean(p >= lambda_)/(1 - lambda_)
         pi0_lambda = pi0
@@ -200,7 +201,7 @@ def pi0est(p_values, lambda_ = np.arange(0.05,1.0,0.05), pi0_method = "smoother"
         for l in lambda_:
             pi0.append(np.mean(p >= l)/(1 - l))
         pi0_lambda = pi0
-
+    
         if (pi0_method == "smoother"):
             if smooth_log_pi0:
                 pi0 = np.log(pi0)
@@ -227,7 +228,7 @@ def pi0est(p_values, lambda_ = np.arange(0.05,1.0,0.05), pi0_method = "smoother"
     if (pi0<=0):
         plot_hist(p, f"p-value density histogram used during pi0 estimation", "p-value", "density histogram", "pi0_estimation_error_pvalue_histogram_plot.pdf")
         raise click.ClickException(f"The estimated pi0 <= 0. Check that you have valid p-values or use a different range of lambda. Current lambda range: {lambda_}")
-
+    
     return {'pi0': pi0, 'pi0_lambda': pi0_lambda, 'lambda_': lambda_, 'pi0_smooth': pi0Smooth}
 
 @profile
@@ -436,12 +437,12 @@ def summary_err_table(df, qvalues=[0, 0.01, 0.02, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
 
 @profile
-def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, pi0_method = "smoother", pi0_smooth_df = 3, pi0_smooth_log_pi0 = False, compute_lfdr = False, lfdr_trunc = True, lfdr_monotone = True, lfdr_transf = "probit", lfdr_adj = 1.5, lfdr_eps = np.power(10.0,-8)):
+def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, pi0_method = "smoother", pi0_smooth_df = 3, pi0_smooth_log_pi0 = False, compute_lfdr = False, lfdr_trunc = True, lfdr_monotone = True, lfdr_transf = "probit", lfdr_adj = 1.5, lfdr_eps = np.power(10.0,-8), sel_column=None, mapper=None, save_report=False, title=None, level=None, working_thread_number=None):
     """ Takes list of decoy and target scores and creates error statistics for target values """
 
     target_scores = to_one_dim_array(target_scores)
     target_scores = np.sort(target_scores[~np.isnan(target_scores)])
-
+    
     decoy_scores = to_one_dim_array(decoy_scores)
     decoy_scores = np.sort(decoy_scores[~np.isnan(decoy_scores)])
 
@@ -452,9 +453,19 @@ def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, 
     else:
         # non-parametric
         target_pvalues = pemp(target_scores, decoy_scores)
-
-    # estimate pi0
-    pi0 = pi0est(target_pvalues, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)
+    
+    if save_report and title is not None and sel_column is not None:
+        # Place pi0 estimation in a try-except block for plot generation only
+        try:
+            # estimate pi0
+            pi0 = pi0est(target_pvalues, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)
+        except:
+            pi0 = None
+        # generate main score selection report
+        main_score_selection_report(title, sel_column, mapper, decoy_scores, target_scores, target_pvalues, pi0, pdf_path=os.path.join(os.path.dirname(title), f"main_score_selection_{level}_report_thread_{working_thread_number}.pdf"), worker_num=working_thread_number)
+    else:
+        # estimate pi0
+        pi0 = pi0est(target_pvalues, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0)
 
     # compute q-value
     target_qvalues = qvalue(target_pvalues, pi0['pi0'], pfdr)
@@ -472,10 +483,10 @@ def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, 
     return error_stat, pi0
 
 
-def find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0):
+def find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, sel_column=None, mapper=None, main_score_selection_report=none, outfile=None, level=None, working_thread_number=None):
     """ Finds cut off target score for specified false discovery rate fdr """
 
-    error_stat, pi0 = error_statistics(tt_scores, td_scores, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, False)
+    error_stat, pi0 = error_statistics(tt_scores, td_scores, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, False, sel_column=sel_column, mapper=mapper, save_report=main_score_selection_report, title=outfile, level=level, working_thread_number=working_thread_number)
     if not len(error_stat):
         raise click.ClickException("Too little data for calculating error statistcs.")
     i0 = (error_stat.qvalue - cutoff_fdr).abs().idxmin()

--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -483,7 +483,7 @@ def error_statistics(target_scores, decoy_scores, parametric, pfdr, pi0_lambda, 
     return error_stat, pi0
 
 
-def find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, sel_column=None, mapper=None, main_score_selection_report=none, outfile=None, level=None, working_thread_number=None):
+def find_cutoff(tt_scores, td_scores, cutoff_fdr, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, sel_column=None, mapper=None, main_score_selection_report=False, outfile=None, level=None, working_thread_number=None):
     """ Finds cut off target score for specified false discovery rate fdr """
 
     error_stat, pi0 = error_statistics(tt_scores, td_scores, parametric, pfdr, pi0_lambda, pi0_method, pi0_smooth_df, pi0_smooth_log_pi0, False, sel_column=sel_column, mapper=mapper, save_report=main_score_selection_report, title=outfile, level=level, working_thread_number=working_thread_number)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(name='pyprophet',
           "hyperopt",
           "statsmodels >= 0.8.0",
           "matplotlib",
-          "tabulate"
+          "tabulate",
+          "PyPDF2"
       ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
# Dynamic selection of main score during initial first past semi-supervised learning

## Error when scoring using XGBoost

```
pyprophet score --in /data/yanliu_I170114_040_PhosNoco10_SW.osw --out /data/test/yanliu_I170114_040_PhosNoco10_SW.osw --classifier XGBoost --xeval_num_iter 3 --ss_num_iter 3 --level ms1ms2 --threads 3 --ss_initial_fdr 0.15 --ss_iteration_fdr 0.05
Info: Enable number of transitions & precursor / product charge scores for XGBoost-based classifier
Info: Learn and apply classifier from input data.
Warning: Column var_mi_ratio_score contains only invalid/missing values. Column will be dropped.
Warning: Column var_elution_model_fit_score contains only invalid/missing values. Column will be dropped.
Warning: Column var_im_xcorr_shape contains only invalid/missing values. Column will be dropped.
Warning: Column var_im_xcorr_coelution contains only invalid/missing values. Column will be dropped.
Warning: Column var_im_delta_score contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_lag contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_shape contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_log_sn contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_log_diff contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_log_trend contains only invalid/missing values. Column will be dropped.
Warning: Column var_sonar_rsq contains only invalid/missing values. Column will be dropped.
Warning: Column var_ms1_im_ms1_delta_score contains only invalid/missing values. Column will be dropped.
Info: Data set contains 7854 decoy and 7993 target groups.
Info: Summary of input data:
Info: 78574 peak groups
Info: 15847 group ids
Info: 37 scores including main score
Info: Semi-supervised learning of weights:
Info: Start learning on 3 folds using 3 processes.
Info: Learning on cross-validation fold.
Info: Learning on cross-validation fold.
Info: Learning on cross-validation fold.
Error: The estimated pi0 <= 0. Check that you have valid p-values or use a different range of lambda. Current lambda range: [0.1  0.15 0.2  0.25 0.3  0.35 0.4  0.45]
```

I usually run into this issue when trying to score using the XGBoost classifier. Usually the suggestion would be to change the `--ss_main_score`, but to find a better starting main score, you either need try test each score one by one, or you have to adjust the `ss_initial_fdr` and `ss_iteration_fdr` until it doesn't run into this error.

I found that this issue occurs when the top decoy data and best target data do no have a good amount of separation, or are very unbalanced after applying the cutoff of the top target scores (in `select_train_peaks`). The resulting classifier score used in iteration semi supervised learning fails to separate between decoy and targets. For example:

```
Info: For Training main_var_xcorr_shape - td_peaks ((3928, 43)) and bt_peaks ((787, 43))
```

### Score Distribution input for **start_semi_supervised_learning**

![image](https://user-images.githubusercontent.com/32938975/207412553-e3c7446c-7dcb-4066-8923-cc4f35c66381.png)

### Score Distribution input for **iter_semi_supervised_learning**

![image](https://user-images.githubusercontent.com/32938975/207412662-6880558b-23f9-4a45-b970-78ed63779c82.png)

Even if you supply the `--ss_main_score` using the score that usually performs the best (**main_var_mi_weighted_score**), depending on the fold and the data split, it still might fail.

### Second Learning Fold when setting `--ss_main_score var_mi_weighted_score`

![image](https://user-images.githubusercontent.com/32938975/207412842-0f412d66-6a37-41b6-a886-11b80a17584e.png)

## Solution

I tried a couple of different approaches, but I found the approach below to be the best:

1. When calling `start_semi_supervised_learning`
   1. Before actually training on the default/selected main score, first permute through the scores to find the score that gives the most balanced data between top decoy peaks and best target peaks (i.e. difference in the shape in number of scores ) after applying the cutoff in `select_train_peaks`
   2. Use the score that has the least difference in number of best targets to top decoys to generate scores for training
   3. train on these scores
2. After initial semi supervised learning
   1. update the training dataframe and the experiment data frame to set the best identifed score (from 1.ii) as the main score
3. proceed with iteration of semi supervised learning 

I added an additional boolean parameter (__**--main_score_selection_report**__: Default is set to False to not generate a report) to module `score`, to optionally save a pdf report of the different individual score distributions and p-value distributions (like the plots above) computed in `error_statistics`. The different score reports get appended to the same file using **PyPDF2**, if the user threads the computation for fold learning, then *N* number of reports will be generated since there will be write conflicts if attempting to write to the same file. I find these reports useful for debugging purposes.

## Comparisons

I ran some tests on a single file from the IPF paper: **yanliu_I170114_040_PhosNoco10_SW.osw**

I compare **LDA** and **XGBoost + main score=var_mi_weighted_score** for PyProphet (v2.1.12) to **LDA**, **XGBoost** and **XGBoost + main score=var_mi_weighted_score** for this implementation (vdynamic). I couldn't test **XGBoost** for PyProphet (v2.1.12)  because it always errors out during pi0 estimation.

![image](https://user-images.githubusercontent.com/32938975/207419311-ed290b70-10e0-4cb7-b570-9e9dd7bdfd94.png)

Total Numbers of IDs is computed from `pyprophet statistics`, and I take the average of these numbers after running the scoring, ipf and context workflow 20 times (which is seen from the standard deviation of the error bars). The changes don't apply to **LDA**, so I tested to make sure the results for **LDA**vv are still consistent. Numbers are fairly consistent between **XGBoost + main score (v2.1.12)**, **XGBoost (vdynamic)** and **XGBoost + main score (vdynamic)** .

## Mean Feature Importance
![image](https://user-images.githubusercontent.com/32938975/207419780-f44e9d94-c365-41e4-9ece-241120c5179e.png)


## Updated parameter in XGBClassifier

The below warning message occurs because `silent` is no longer a parameter in newer versions of XGBoost, it has been changed to `verbosity`, which when set to 0 is equivalent to silent.

```
[05:21:28] WARNING: ../src/learner.cc:767: 
Parameters: { "silent" } are not used.
```

