### PR TITLE
Fix/ipf np int

### DIFF
--- a/pyprophet/ipf.py
+++ b/pyprophet/ipf.py
@@ -15,7 +15,7 @@ def compute_model_fdr(data_in):
     # compute model based FDR estimates from posterior error probabilities
     order = np.argsort(data)
 
-    ranks = np.zeros(data.shape[0], dtype=np.int)
+    ranks = np.zeros(data.shape[0], dtype=int)
     fdr = np.zeros(data.shape[0])
 
     # rank data with with maximum ranks for ties


### PR DESCRIPTION
```
Info: Conducting peptidoform-level inference.
Traceback (most recent call last):
  File "/home/roestlab/anaconda3/envs/py39_JS/bin/pyprophet", line 33, in <module>
    sys.exit(load_entry_point('pyprophet', 'console_scripts', 'pyprophet')())
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    rv.append(sub_ctx.command.invoke(sub_ctx))
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/media/roestlab/Data1/User/JustinS/Development/for_pr/pyprophet/pyprophet/main.py", line 142, in ipf
    infer_peptidoforms(infile, outfile, ipf_ms1_scoring, ipf_ms2_scoring, ipf_h0, ipf_grouped_fdr, ipf_max_precursor_pep, ipf_max_peakgroup_pep, ipf_max_precursor_peakgroup_pep, ipf_max_transition_pep)
  File "/media/roestlab/Data1/User/JustinS/Development/for_pr/pyprophet/pyprophet/ipf.py", line 371, in infer_peptidoforms
    peptidoform_data = peptidoform_inference(peptidoform_table, precursor_data, ipf_grouped_fdr)
  File "/media/roestlab/Data1/User/JustinS/Development/for_pr/pyprophet/pyprophet/ipf.py", line 352, in peptidoform_inference
    pf_pp_data['qvalue'] = pd.merge(pf_pp_data, transition_data_bm[['feature_id', 'num_peptidoforms']].drop_duplicates(), on=['feature_id'], how='inner').groupby('num_peptidoforms')['pep'].transform(compute_model_fdr)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/pandas/core/groupby/generic.py", line 428, in transform
    return self._transform(
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/pandas/core/groupby/groupby.py", line 1642, in _transform
    return self._transform_general(func, *args, **kwargs)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/pandas/core/groupby/generic.py", line 459, in _transform_general
    res = func(group, *args, **kwargs)
  File "/media/roestlab/Data1/User/JustinS/Development/for_pr/pyprophet/pyprophet/ipf.py", line 18, in compute_model_fdr
    ranks = np.zeros(data.shape[0], dtype=np.int)
  File "/home/roestlab/anaconda3/envs/py39_JS/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```