### PR TITLE
[FEATURE] add feature names to xgboost output

### DIFF
--- a/pyprophet/pyprophet.py
+++ b/pyprophet/pyprophet.py
@@ -347,7 +347,12 @@ class HolyGostQuery(object):
 
         result = Result(summary_statistics, final_statistics, scored_table)
 
+        # Set feature names in XGBoost classifier
+        if self.classifier == "XGBoost":
+            classifier_table.feature_names = list(score_columns)
+
         click.echo("Info: Finished scoring and estimation statistics.")
+
         return result, scorer, classifier_table
 
 


### PR DESCRIPTION
Problem: Currently XGBoost model does not store feature names, just stored as f1...fn. 


Solution:Before exporting the model add the feature names.