### PR TITLE
Continous Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
-        pip install numpy
         pip install .
 
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: continuous-integration
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest] # remove mac tests
+        # Latest pyOpenMS supports Python 3.10, and 3.11
+        python-version: ["3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+        pip install .
+
+    - name: Test
+      run: |
+        python -m pytest tests/ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest] # remove mac tests
+        os: [ubuntu-latest]
+          #os: [ubuntu-latest, windows-latest, macos-latest] # remove mac tests
         # Latest pyOpenMS supports Python 3.10, and 3.11
         python-version: ["3.10", "3.11"]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
+        pip install numpy
         pip install .
 
     - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         pip install pytest
         pip install .
 
+    - name: Compile cython module
+      run: python setup.py build_ext --inplace 
+
     - name: Test
       run: |
         python -m pytest tests/ 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
 pyprophet = "pyprophet.main:cli"
 
 [tool.setuptools]
-packages = ["pyprophet"]
+packages = { find = { exclude = ["ez_setup", "examples", "tests"] } }
 include-package-data = true
 zip-safe = false
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "cython"]  # Dependencies needed to build the package
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyprophet"
+version = "2.2.8"
+description = "PyProphet: Semi-supervised learning and scoring of OpenSWATH results."
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { text = "BSD" }
+authors = [{ name = "The PyProphet Developers", email = "rocksportrocker@gmail.com" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "Topic :: Scientific/Engineering :: Chemistry"
+]
+keywords = ["bioinformatics", "openSWATH", "mass spectrometry"]
+
+# Dependencies required for runtime
+dependencies = [
+    "Click",
+    "duckdb",
+    "numpy >= 1.9.0",
+    "scipy",
+    "pandas >= 0.17",
+    "cython",
+    "numexpr >= 2.10.1",
+    "scikit-learn >= 0.17",
+    "xgboost",
+    "hyperopt",
+    "statsmodels >= 0.8.0",
+    "matplotlib",
+    "tabulate",
+    "pyarrow",
+    "pypdf"
+]
+
+# Define console entry points
+[project.scripts]
+pyprophet = "pyprophet.main:cli"
+
+[tool.setuptools]
+packages = ["pyprophet"]
+include-package-data = true
+zip-safe = false
+

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,20 @@
-import sys
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_packages
 from Cython.Build import cythonize
 import numpy
 
-use_cython = True
-ext = ".pyx" if use_cython else ".c"
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    use_cython = False
+else:
+    use_cython = True
 
-extensions = [
-    Extension(
-        "pyprophet._optimized",
-        [f"pyprophet/_optimized{ext}"],
-        include_dirs=[numpy.get_include()],
-    )
-]
-
+ext_modules = []
 if use_cython:
-    extensions = cythonize(extensions)
+    ext_modules += [Extension("pyprophet._optimized", ["pyprophet/_optimized.pyx"])]
+    ext_modules = cythonize(ext_modules)
+else:
+    ext_modules += [Extension("pyprophet._optimized", ["pyprophet/_optimized.c"])]
 
-setup(
-    ext_modules=extensions,
-)
+setup(name='pyprophet', ext_modules=ext_modules, include_dirs=[numpy.get_include()])
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 import sys
-#import numpy
 from setuptools import setup, find_packages
 from distutils.extension import Extension
+
+try:
+    import numpy
+except ImportError:
+    print("Numpy is not installed. Installing it now.")
+    import subprocess
+    subprocess.check_call(['pip', 'install', 'numpy'])
+    import numpy
 
 try:
     from Cython.Build import cythonize
@@ -36,6 +43,7 @@ setup(name='pyprophet',
       url="https://github.com/PyProphet/pyprophet",
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
+      include_dirs=[numpy.get_include()],
       classifiers=[
           'Development Status :: 3 - Alpha',
           'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys
-import numpy
+#import numpy
 from setuptools import setup, find_packages
 from distutils.extension import Extension
 
@@ -36,7 +36,6 @@ setup(name='pyprophet',
       url="https://github.com/PyProphet/pyprophet",
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
-      include_dirs=[numpy.get_include()],
       classifiers=[
           'Development Status :: 3 - Alpha',
           'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -1,80 +1,23 @@
 import sys
-from setuptools import setup, find_packages
-from distutils.extension import Extension
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+import numpy
 
-try:
-    import numpy
-except ImportError:
-    print("Numpy is not installed. Installing it now.")
-    import subprocess
-    subprocess.check_call(['pip', 'install', 'numpy'])
-    import numpy
+use_cython = True
+ext = ".pyx" if use_cython else ".c"
 
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    use_cython = False
-else:
-    use_cython = True
-
-cmdclass = {}
-ext_modules = []
+extensions = [
+    Extension(
+        "pyprophet._optimized",
+        [f"pyprophet/_optimized{ext}"],
+        include_dirs=[numpy.get_include()],
+    )
+]
 
 if use_cython:
-    ext_modules += [Extension("pyprophet._optimized", ["pyprophet/_optimized.pyx"])]
-    ext_modules = cythonize(ext_modules)
-else:
-    ext_modules += [Extension("pyprophet._optimized", ["pyprophet/_optimized.c"])]
+    extensions = cythonize(extensions)
 
-# read the contents of README for PyPI
-from os import path
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+setup(
+    ext_modules=extensions,
+)
 
-setup(name='pyprophet',
-      version="2.2.8",
-      author="The PyProphet Developers",
-      author_email="rocksportrocker@gmail.com",
-      description="PyProphet: Semi-supervised learning and scoring of OpenSWATH results.",
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      license="BSD",
-      url="https://github.com/PyProphet/pyprophet",
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      include_dirs=[numpy.get_include()],
-      classifiers=[
-          'Development Status :: 3 - Alpha',
-          'Environment :: Console',
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: BSD License',
-          'Operating System :: OS Independent',
-          'Topic :: Scientific/Engineering :: Bio-Informatics',
-          'Topic :: Scientific/Engineering :: Chemistry',
-      ],
-      zip_safe=False,
-      install_requires=[
-          "Click",
-          "duckdb",
-          "numpy >= 1.9.0",
-          "scipy",
-          "pandas >= 0.17",
-          "cython",
-          "numexpr >= 2.10.1",
-          "scikit-learn >= 0.17",
-          "xgboost",
-          "hyperopt",
-          "statsmodels >= 0.8.0",
-          "matplotlib",
-          "tabulate",
-          "pyarrow",
-          "pypdf"
-      ],
-      entry_points={
-          'console_scripts': [
-              "pyprophet=pyprophet.main:cli",
-              ]
-      },
-      ext_modules=ext_modules,
-      )


### PR DESCRIPTION
This adds continuous integration tests (using the existing pyprophet tests) to pyprophet using github actions.

Note this uses pytest instead of nose because nose is no longer being maintained.

Many tests are currently failing so ideally we can address why they are failing before merging. 