### PR TITLE
add: export sqMass to parquet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,14 @@ RUN pip install numpy cython
 
 # install duckdb and its extensions before pyprophet
 RUN pip install duckdb
-RUN python -c "import duckdb; conn = duckdb.connect(); conn.execute(\"INSTALL 'sqlite_scanner'\"); conn.execute(\"LOAD 'sqlite_scanner'\");"
+
 
 # install PyProphet and dependencies
 ADD . /pyprophet
 WORKDIR /pyprophet
 # RUN python setup.py install
 RUN pip install .
+RUN python -c "import duckdb; conn = duckdb.connect(); conn.execute(\"INSTALL 'sqlite_scanner'\"); conn.execute(\"LOAD 'sqlite_scanner'\");"
 WORKDIR /
 RUN rm -rf /pyprophet
 

--- a/pyprophet/export_parquet.py
+++ b/pyprophet/export_parquet.py
@@ -357,7 +357,7 @@ def convert_osw_to_parquet(infile, outfile, compression_method='zstd', compressi
     )
     precursor_columns = conn.execute("PRAGMA table_info(PRECURSOR)").df()['name'].values
     has_library_drift_time = 'LIBRARY_DRIFT_TIME' in precursor_columns
-    
+
     query = query.format(
         library_drift_time_field=""",
         PRECURSOR.LIBRARY_DRIFT_TIME AS PRECURSOR_LIBRARY_DRIFT_TIME""" if has_library_drift_time else """,
@@ -567,9 +567,141 @@ def convert_osw_to_parquet(infile, outfile, compression_method='zstd', compressi
         pl.col("FEATURE_ID").cast(pl.Int64)
     )
 
+    conn.close()
+
     # Write to parquet
     master_df.write_parquet(
         outfile,
         compression=compression_method,
         compression_level=compression_level
+    )
+
+
+def convert_sqmass_to_parquet(
+    infile, outfile, oswfile, compression_method="zstd", compression_level=11
+):
+    '''
+    Convert a SQMass sqlite file to Parquet format
+    '''
+    xic_conn = duckdb.connect(database=infile, read_only=True)
+    osw_conn = duckdb.connect(database=oswfile, read_only=True)
+
+    query = """
+    SELECT
+    PRECURSOR.ID AS PRECURSOR_ID,
+    TRANSITION.ID AS TRANSITION_ID,
+    PEPTIDE.MODIFIED_SEQUENCE,
+    PRECURSOR.CHARGE AS PRECURSOR_CHARGE,
+    TRANSITION.CHARGE AS PRODUCT_CHARGE,
+    PRECURSOR.DECOY AS PRECURSOR_DECOY,
+    TRANSITION.DECOY AS PRODUCT_DECOY,
+    FROM PRECURSOR
+    INNER JOIN PRECURSOR_PEPTIDE_MAPPING ON PRECURSOR.ID = PRECURSOR_PEPTIDE_MAPPING.PRECURSOR_ID
+    INNER JOIN PEPTIDE ON PRECURSOR_PEPTIDE_MAPPING.PEPTIDE_ID = PEPTIDE.ID
+    INNER JOIN TRANSITION_PRECURSOR_MAPPING ON PRECURSOR.ID = TRANSITION_PRECURSOR_MAPPING.PRECURSOR_ID
+    INNER JOIN TRANSITION ON TRANSITION_PRECURSOR_MAPPING.TRANSITION_ID = TRANSITION.ID
+    """
+    osw_df = osw_conn.execute(query).pl()
+
+    query = """
+    SELECT
+    CHROMATOGRAM.NATIVE_ID,
+    DATA.COMPRESSION,
+    DATA.DATA_TYPE,
+    DATA.DATA
+    FROM CHROMATOGRAM
+    INNER JOIN DATA ON DATA.CHROMATOGRAM_ID = CHROMATOGRAM.ID
+    """
+    chrom_df = xic_conn.execute(query).pl()
+    
+    xic_conn.close()
+    osw_conn.close()
+
+    chrom_df_prec = (
+        chrom_df.filter(chrom_df["NATIVE_ID"].str.contains("_Precursor_i\\d+"))
+        # Add column with just the precursor id - now operating on the filtered DataFrame
+        .with_columns(
+            pl.col("NATIVE_ID")
+            .str.extract(r"(\d+)_Precursor_i\d+")
+            .alias("PRECURSOR_ID")
+            .cast(pl.Int64)
+        )
+    )
+
+    chrom_df_trans = (
+        chrom_df.filter(~chrom_df["NATIVE_ID"].str.contains("_Precursor_i\\d+"))
+        # Add column with just the transition id - now operating on the filtered DataFrame
+        .with_columns(pl.col("NATIVE_ID").alias("TRANSITION_ID").cast(pl.Int64))
+    )
+
+    # Join osw_df and chrom_df_prec on PRECURSOR_ID
+    chrom_df_prec_m = (
+        osw_df.select(
+            ["PRECURSOR_ID", "MODIFIED_SEQUENCE", "PRECURSOR_CHARGE", "PRECURSOR_DECOY"]
+        )
+        .unique()
+        .with_columns(
+            pl.lit(None).cast(pl.Int64).alias("TRANSITION_ID"),
+            pl.lit(None).cast(pl.Int64).alias("PRODUCT_CHARGE"),
+            pl.lit(None).cast(pl.Int64).alias("PRODUCT_DECOY"),
+        )
+        .select(
+            [
+                "PRECURSOR_ID",
+                "TRANSITION_ID",
+                "MODIFIED_SEQUENCE",
+                "PRECURSOR_CHARGE",
+                "PRODUCT_CHARGE",
+                "PRECURSOR_DECOY",
+                "PRODUCT_DECOY",
+            ]
+        )
+        .join(
+            chrom_df_prec,
+            left_on="PRECURSOR_ID",
+            right_on="PRECURSOR_ID",
+            how="inner",
+            coalesce=True,
+        )
+    )
+
+    chrom_df_trans_m = osw_df.join(
+        chrom_df_trans,
+        left_on="TRANSITION_ID",
+        right_on="TRANSITION_ID",
+        how="inner",
+        coalesce=True,
+    )
+
+    chrom_df_m = chrom_df_prec_m.vstack(chrom_df_trans_m).sort(by=["PRECURSOR_ID"])
+
+    chrom_df_restructured = chrom_df_m.pivot(
+        values=["DATA", "COMPRESSION"],
+        index=[
+            "PRECURSOR_ID",
+            "TRANSITION_ID",
+            "MODIFIED_SEQUENCE",
+            "PRECURSOR_CHARGE",
+            "PRODUCT_CHARGE",
+            "PRECURSOR_DECOY",
+            "PRODUCT_DECOY",
+            "NATIVE_ID",
+        ],
+        on="DATA_TYPE",
+        aggregate_function="first",
+    )
+
+    chrom_df_restructured = chrom_df_restructured.rename(
+        {
+            "DATA_1": "INTENSITY_DATA",
+            "DATA_2": "RT_DATA",
+            "COMPRESSION_1": "INTENSITY_COMPRESSION",
+            "COMPRESSION_2": "RT_COMPRESSION",
+        }
+    )
+    
+    chrom_df_restructured.write_parquet(
+        outfile,
+        compression=compression_method,
+        compression_level=compression_level,
     )

--- a/pyprophet/export_parquet.py
+++ b/pyprophet/export_parquet.py
@@ -601,6 +601,7 @@ def convert_sqmass_to_parquet(
     PEPTIDE.MODIFIED_SEQUENCE,
     PRECURSOR.CHARGE AS PRECURSOR_CHARGE,
     TRANSITION.CHARGE AS PRODUCT_CHARGE,
+    TRANSITION.DETECTING AS DETECTING_TRANSITION,
     PRECURSOR.DECOY AS PRECURSOR_DECOY,
     TRANSITION.DECOY AS PRODUCT_DECOY,
     FROM PRECURSOR
@@ -651,6 +652,7 @@ def convert_sqmass_to_parquet(
         .with_columns(
             pl.lit(None).cast(pl.Int64).alias("TRANSITION_ID"),
             pl.lit(None).cast(pl.Int64).alias("PRODUCT_CHARGE"),
+            pl.lit(1).cast(pl.Int64).alias("DETECTING_TRANSITION"),
             pl.lit(None).cast(pl.Int64).alias("PRODUCT_DECOY"),
         )
         .select(
@@ -660,6 +662,7 @@ def convert_sqmass_to_parquet(
                 "MODIFIED_SEQUENCE",
                 "PRECURSOR_CHARGE",
                 "PRODUCT_CHARGE",
+                "DETECTING_TRANSITION",
                 "PRECURSOR_DECOY",
                 "PRODUCT_DECOY",
             ]
@@ -691,6 +694,7 @@ def convert_sqmass_to_parquet(
             "MODIFIED_SEQUENCE",
             "PRECURSOR_CHARGE",
             "PRODUCT_CHARGE",
+            "DETECTING_TRANSITION",
             "PRECURSOR_DECOY",
             "PRODUCT_DECOY",
             "NATIVE_ID",

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -17,7 +17,7 @@ from .export_compound import export_compound_tsv
 from .glyco.export import export_tsv as export_glyco_tsv, export_score_plots as export_glyco_score_plots
 from .filter import filter_sqmass, filter_osw
 from .data_handling import (transform_pi0_lambda, transform_threads, transform_subsample_ratio, check_sqlite_table)
-from .export_parquet import export_to_parquet, convert_osw_to_parquet
+from .export_parquet import export_to_parquet, convert_osw_to_parquet, convert_sqmass_to_parquet
 from functools import update_wrapper
 import sqlite3
 from tabulate import tabulate
@@ -558,8 +558,9 @@ def export(
 
 # Export to Parquet
 @cli.command()
-@click.option('--in', 'infile', required=True, type=click.Path(exists=True), help='PyProphet input file.')
+@click.option('--in', 'infile', required=True, type=click.Path(exists=True), help='PyProphet OSW or sqMass input file.')
 @click.option('--out', 'outfile', required=False, type=click.Path(exists=False), help='Output parquet file.')
+@click.option('--oswfile', 'oswfile', required=False, type=click.Path(exists=False), help='OSW file.')
 @click.option('--transitionLevel', 'transitionLevel', is_flag=True, help='Whether to export transition level data as well')
 @click.option('--onlyFeatures', 'onlyFeatures', is_flag=True, help='Only include precursors that have a corresponding feature')
 @click.option('--noDecoys', 'noDecoys', is_flag=True, help='Do not include decoys in the exported data')
@@ -567,29 +568,42 @@ def export(
 @click.option('--scoring_format', 'scoring_format', is_flag=True, help='Convert to parquet format that is compatible with the scoring/inference modules')
 @click.option('--compression', 'compression', default='zstd', show_default=True, type=click.Choice(['lz4', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'zstd']), help='Compression algorithm to use for parquet file.')
 @click.option('--compression_level', 'compression_level', default=11, show_default=True, type=int, help='Compression level to use for parquet file.')
-def export_parquet(infile, outfile, transitionLevel, onlyFeatures, noDecoys, scoring_format, compression, compression_level):
+def export_parquet(infile, outfile, oswfile, transitionLevel, onlyFeatures, noDecoys, scoring_format, compression, compression_level):
     """
     Export all transition data to parquet file or convert to parquet scoring format for scoring and inference.
     """
-    if scoring_format:
-        click.echo("Info: Will export OSW to parquet scoring format")
+    # Check if the input file has an .osw extension
+    if infile.endswith('.osw'):
+        if scoring_format:
+            click.echo("Info: Will export OSW to parquet scoring format")
+            if os.path.exists(outfile):
+                click.echo(click.style(f"Warn: {outfile} already exists, will overwrite", fg='yellow'))
+            start = time.time()
+            convert_osw_to_parquet(infile, outfile, compression_method=compression, compression_level=compression_level)
+            end = time.time()
+            click.echo(f"Info: {outfile} written in {end-start:.4f} seconds")
+        else:
+            if transitionLevel:
+                click.echo("Info: Will export transition level data")
+            if outfile is None:
+                outfile = infile.split(".osw")[0] + ".parquet"
+            if os.path.exists(outfile):
+                overwrite = click.confirm(f"{outfile} already exists, would you like to overwrite?")
+                if not overwrite:
+                    raise click.ClickException(f"Aborting: {outfile} already exists!")
+            click.echo("Info: Parquet file will be written to {}".format(outfile))
+            export_to_parquet(os.path.abspath(infile), os.path.abspath(outfile), transitionLevel, onlyFeatures, noDecoys)
+    elif infile.endswith('.sqmass') or infile.endswith('.sqMass'):
+        click.echo("Info: Will export sqMass to parquet scoring format")
         if os.path.exists(outfile):
             click.echo(click.style(f"Warn: {outfile} already exists, will overwrite", fg='yellow'))
         start = time.time()
-        convert_osw_to_parquet(infile, outfile, compression_method=compression, compression_level=compression_level)
+        convert_sqmass_to_parquet(infile, outfile, oswfile, compression_method=compression, compression_level=compression_level)
         end = time.time()
         click.echo(f"Info: {outfile} written in {end-start:.4f} seconds")
     else:
-        if transitionLevel:
-            click.echo("Info: Will export transition level data")
-        if outfile is None:
-            outfile = infile.split(".osw")[0] + ".parquet"
-        if os.path.exists(outfile):
-            overwrite = click.confirm(f"{outfile} already exists, would you like to overwrite?")
-            if not overwrite:
-                raise click.ClickException(f"Aborting: {outfile} already exists!")
-        click.echo("Info: Parquet file will be written to {}".format(outfile))
-        export_to_parquet(os.path.abspath(infile), os.path.abspath(outfile), transitionLevel, onlyFeatures, noDecoys)
+        raise click.ClickException("Input file must be of type .osw or .sqmass/.sqMass")
+
 
 # Export Compound TSV
 @cli.command()

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -560,17 +560,17 @@ def export(
 @cli.command()
 @click.option('--in', 'infile', required=True, type=click.Path(exists=True), help='PyProphet OSW or sqMass input file.')
 @click.option('--out', 'outfile', required=False, type=click.Path(exists=False), help='Output parquet file.')
-@click.option('--oswfile', 'oswfile', required=False, type=click.Path(exists=False), help='OSW file.')
+@click.option('--oswfile', 'oswfile', required=False, type=click.Path(exists=False), help='PyProphet OSW file. Only required when converting sqMass to parquet.')
 @click.option('--transitionLevel', 'transitionLevel', is_flag=True, help='Whether to export transition level data as well')
 @click.option('--onlyFeatures', 'onlyFeatures', is_flag=True, help='Only include precursors that have a corresponding feature')
 @click.option('--noDecoys', 'noDecoys', is_flag=True, help='Do not include decoys in the exported data')
 # Convert to scoring format
-@click.option('--scoring_format', 'scoring_format', is_flag=True, help='Convert to parquet format that is compatible with the scoring/inference modules')
+@click.option('--scoring_format', 'scoring_format', is_flag=True, help='Convert OSW to parquet format that is compatible with the scoring/inference modules')
 @click.option('--compression', 'compression', default='zstd', show_default=True, type=click.Choice(['lz4', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'zstd']), help='Compression algorithm to use for parquet file.')
 @click.option('--compression_level', 'compression_level', default=11, show_default=True, type=int, help='Compression level to use for parquet file.')
 def export_parquet(infile, outfile, oswfile, transitionLevel, onlyFeatures, noDecoys, scoring_format, compression, compression_level):
     """
-    Export all transition data to parquet file or convert to parquet scoring format for scoring and inference.
+    Export OSW or sqMass to parquet format
     """
     # Check if the input file has an .osw extension
     if infile.endswith('.osw'):

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -594,7 +594,7 @@ def export_parquet(infile, outfile, oswfile, transitionLevel, onlyFeatures, noDe
             click.echo("Info: Parquet file will be written to {}".format(outfile))
             export_to_parquet(os.path.abspath(infile), os.path.abspath(outfile), transitionLevel, onlyFeatures, noDecoys)
     elif infile.endswith('.sqmass') or infile.endswith('.sqMass'):
-        click.echo("Info: Will export sqMass to parquet scoring format")
+        click.echo("Info: Will export sqMass to parquet")
         if os.path.exists(outfile):
             click.echo(click.style(f"Warn: {outfile} already exists, will overwrite", fg='yellow'))
         start = time.time()


### PR DESCRIPTION
This PR adds support for `sqMass` to parquet file conversion. 

### Enhancements for `sqMass` file support:
* Added a new function, `convert_sqmass_to_parquet`, to convert `sqMass` SQLite files to Parquet format. This includes logic for querying and restructuring chromatogram and transition data. (`pyprophet/export_parquet.py`, [pyprophet/export_parquet.pyR577-R715](diffhunk://#diff-7e031ee98e21806a5e657556e31b5f400b0491ee2af66a788f39d7372a9c84a7R577-R715))
* Updated the CLI `export` command to support `sqMass` file input, with appropriate checks for file extensions and output overwriting warnings. (`pyprophet/main.py`, [[1]](diffhunk://#diff-8da304718980ac3b91fcd2adc8868136a7fb3d3fa596151858815e40404e1e14L561-R576) [[2]](diffhunk://#diff-8da304718980ac3b91fcd2adc8868136a7fb3d3fa596151858815e40404e1e14R596-R606)

### Modularization of DuckDB extension handling:
* Introduced the `load_sqlite_scanner` function to encapsulate the logic for installing and loading the `sqlite_scanner` DuckDB extension, replacing repetitive code in multiple functions. (`pyprophet/export_parquet.py`, [pyprophet/export_parquet.pyR10-R29](diffhunk://#diff-7e031ee98e21806a5e657556e31b5f400b0491ee2af66a788f39d7372a9c84a7R10-R29))
* Refactored existing functions (`export_to_parquet` and `convert_osw_to_parquet`) to use the new `load_sqlite_scanner` function to check for sqlite_scanner installation. (`pyprophet/export_parquet.py`, [[1]](diffhunk://#diff-7e031ee98e21806a5e657556e31b5f400b0491ee2af66a788f39d7372a9c84a7L50-R70) [[2]](diffhunk://#diff-7e031ee98e21806a5e657556e31b5f400b0491ee2af66a788f39d7372a9c84a7R326)

### Dockerfile improvement:
* Moved the DuckDB `sqlite_scanner` extension installation and loading command to a more appropriate location in the `Dockerfile` to ensure sqlite_scanner extension gets installed. (`Dockerfile`, [DockerfileL9-R16](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L9-R16))

### Minor updates:
* Updated imports in `pyprophet/main.py` to include the new `convert_sqmass_to_parquet` function. (`pyprophet/main.py`, [pyprophet/main.pyL20-R20](diffhunk://#diff-8da304718980ac3b91fcd2adc8868136a7fb3d3fa596151858815e40404e1e14L20-R20))