### PR TITLE
Patch/pq memory opt

### DIFF
--- a/pyprophet/data_handling.py
+++ b/pyprophet/data_handling.py
@@ -119,8 +119,12 @@ def create_index_if_not_exists(con, index_name, table_name, column_name):
 
 
 def is_parquet_file(file_path):
+    '''
+    Check if the file is a valid Parquet file.
+    '''
     import pyarrow.parquet as pq
     from pyarrow.lib import ArrowInvalid, ArrowIOError
+    
     # First check extension
     if not os.path.splitext(file_path)[1].lower() in ('.parquet', '.pq'):
         return False
@@ -131,6 +135,29 @@ def is_parquet_file(file_path):
         return True
     except (ArrowInvalid, ArrowIOError, OSError):
         return False
+    
+def is_valid_split_parquet_dir(path):
+    '''
+    Checks if the directory contains both required parquet files
+    and that each is a valid Parquet file.
+    '''
+    if not os.path.isdir(path):
+        return False
+
+    required_files = [
+        "precursors_features.parquet",
+        "transition_features.parquet"
+    ]
+    
+    for filename in required_files:
+        full_path = os.path.join(path, filename)
+        if not os.path.isfile(full_path):
+            return False
+        if not is_parquet_file(full_path):
+            return False
+
+    return True
+
 
 def get_parquet_column_names(file_path):
     """

--- a/pyprophet/data_handling.py
+++ b/pyprophet/data_handling.py
@@ -15,6 +15,13 @@ except NameError:
     def profile(fun):
         return fun
 
+def format_bytes(size):
+    for unit in ['B', 'KB', 'MB', 'GB']:
+        if size < 1024.0:
+            return f"{size:.2f} {unit}"
+        size /= 1024.0
+    return f"{size:.2f} TB"
+
 # selection of scores with low cross-correlation for metabolomics scoring
 def use_metabolomics_scores():
     return [

--- a/pyprophet/export_parquet.py
+++ b/pyprophet/export_parquet.py
@@ -400,7 +400,7 @@ def convert_osw_to_parquet(
     feature_transition_cols = get_table_columns(infile, "FEATURE_TRANSITION")
     feature_transition_cols.remove("FEATURE_ID")
     feature_transition_cols.remove("TRANSITION_ID")
-    feature_transition_cols = [f"{col} AS FEATURE_TRANSITION_{col}" for col in feature_transition_cols]
+    feature_transition_cols = ["FEATURE_ID"] + [f"{col} AS FEATURE_TRANSITION_{col}" for col in feature_transition_cols]
     feature_transition_cols_sql = ', '.join([f"FEATURE_TRANSITION.{col}" for col in feature_transition_cols])
         
     if split_transition_data:

--- a/pyprophet/export_parquet.py
+++ b/pyprophet/export_parquet.py
@@ -492,6 +492,7 @@ def convert_osw_to_parquet(
 
         transition_template = """
         SELECT 
+            FEATURE.RUN_ID AS RUN_ID,
             TRANSITION_PEPTIDE_MAPPING.PEPTIDE_ID AS IPF_PEPTIDE_ID,
             TRANSITION_PRECURSOR_MAPPING.PRECURSOR_ID AS PRECURSOR_ID,
             TRANSITION.ID AS TRANSITION_ID,
@@ -512,6 +513,11 @@ def convert_osw_to_parquet(
             ON TRANSITION.ID = TRANSITION_PEPTIDE_MAPPING.TRANSITION_ID
         FULL JOIN sqlite_scan('{infile}', 'FEATURE_TRANSITION') AS FEATURE_TRANSITION 
             ON TRANSITION.ID = FEATURE_TRANSITION.TRANSITION_ID
+        FULL JOIN (
+            SELECT ID, RUN_ID
+            FROM sqlite_scan('{infile}', 'FEATURE')
+        ) AS FEATURE
+            ON FEATURE_TRANSITION.FEATURE_ID = FEATURE.ID
         """
 
         transition_query = transition_template.format(

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -571,7 +571,6 @@ def export(
 @click.option('--split_transition_data/--no-split_transition_data', 'split_transition_data', default=False, show_default=True, help='Split transition data into a separate parquet (default: True).')
 @click.option('--compression', 'compression', default='zstd', show_default=True, type=click.Choice(['lz4', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'zstd']), help='Compression algorithm to use for parquet file.')
 @click.option('--compression_level', 'compression_level', default=11, show_default=True, type=int, help='Compression level to use for parquet file.')
-@click.option('--batch_size', 'batch_size', default=500_000, show_default=True, type=int, help='Batch size to write N row chunks of data to the parquet file.')
 def export_parquet(
     infile,
     outfile,
@@ -582,8 +581,7 @@ def export_parquet(
     scoring_format,
     split_transition_data,
     compression,
-    compression_level,
-    batch_size,
+    compression_level
 ):
     """
     Export OSW or sqMass to parquet format
@@ -620,8 +618,7 @@ def export_parquet(
                 outfile,
                 compression_method=compression,
                 compression_level=compression_level,
-                split_transition_data=split_transition_data,
-                batch_size=batch_size,
+                split_transition_data=split_transition_data
             )
             end = time.time()
             mem_after = process.memory_info().rss

--- a/pyprophet/main.py
+++ b/pyprophet/main.py
@@ -3,7 +3,6 @@ import numpy as np
 import click
 import sys
 import os
-import psutil
 import pathlib
 import shutil
 import ast
@@ -18,7 +17,7 @@ from .export import export_tsv, export_score_plots
 from .export_compound import export_compound_tsv
 from .glyco.export import export_tsv as export_glyco_tsv, export_score_plots as export_glyco_score_plots
 from .filter import filter_sqmass, filter_osw
-from .data_handling import (format_bytes, transform_pi0_lambda, transform_threads, transform_subsample_ratio, check_sqlite_table)
+from .data_handling import (transform_pi0_lambda, transform_threads, transform_subsample_ratio, check_sqlite_table)
 from .export_parquet import export_to_parquet, convert_osw_to_parquet, convert_sqmass_to_parquet
 from functools import update_wrapper
 import sqlite3
@@ -611,8 +610,6 @@ def export_parquet(
                 )
 
             start = time.time()
-            process = psutil.Process(os.getpid())
-            mem_before = process.memory_info().rss
             convert_osw_to_parquet(
                 infile,
                 outfile,
@@ -621,10 +618,8 @@ def export_parquet(
                 split_transition_data=split_transition_data
             )
             end = time.time()
-            mem_after = process.memory_info().rss
-            mem_used = mem_after - mem_before
             click.echo(
-                f"Info: {outfile} written in {end-start:.4f} seconds. Approx. memory used: {format_bytes(mem_used)}"
+                f"Info: {outfile} written in {end-start:.4f} seconds."
             )
 
         else:
@@ -655,8 +650,6 @@ def export_parquet(
                 )
             )
         start = time.time()
-        process = psutil.Process(os.getpid())
-        mem_before = process.memory_info().rss
         convert_sqmass_to_parquet(
             infile,
             outfile,
@@ -665,10 +658,8 @@ def export_parquet(
             compression_level=compression_level,
         )
         end = time.time()
-        mem_after = process.memory_info().rss
-        mem_used = mem_after - mem_before
         click.echo(
-            f"Info: {outfile} written in {end-start:.4f} seconds. Approx. memory used: {format_bytes(mem_used)}"
+            f"Info: {outfile} written in {end-start:.4f} seconds."
         )
     else:
         raise click.ClickException("Input file must be of type .osw or .sqmass/.sqMass")

--- a/pyprophet/reader.py
+++ b/pyprophet/reader.py
@@ -1,0 +1,303 @@
+import os
+import click
+import polars as pl
+import pandas as pd
+import duckdb
+from .data_handling import get_parquet_column_names
+
+
+def read_parquet_dir(
+    infile,
+    level,
+    classifier,
+    ss_main_score,
+    ipf_max_peakgroup_rank,
+    ipf_max_peakgroup_pep,
+    ipf_max_transition_isotope_overlap,
+    ipf_min_transition_sn,
+):
+    '''
+    Read the parquet files from the input directory and return a pandas dataframe.
+    '''
+
+    precursor_file = os.path.join(infile, "precursors_features.parquet")
+    transition_file = os.path.join(infile, "transition_features.parquet")
+    alignment_file = os.path.join(infile, "feature_alignment.parquet")
+
+    all_precursor_column_names = get_parquet_column_names(precursor_file)
+    all_transition_column_names = get_parquet_column_names(transition_file)
+
+    if level == "alignment":
+        if  os.path.exists(alignment_file):
+            all_alignment_column_names = get_parquet_column_names(alignment_file)
+        else:
+            click.echo(click.style(f"Error: Couldn't find: {alignment_file}", fg="red"))
+            raise click.ClickException(
+                click.style(
+                "Alignment-level features are not present in the input parquet directory. Please run ARYCAL first to perform alignment of features. https://github.com/singjc/arycal", fg="red")
+            )
+        
+
+    con = duckdb.connect()
+    con.execute(
+        f"CREATE VIEW precursors AS SELECT * FROM read_parquet('{precursor_file}')"
+    )
+    if (
+        os.path.exists(transition_file)
+        and os.path.basename(transition_file) == "transition_features.parquet"
+    ):
+        con.execute(
+            f"CREATE VIEW transitions AS SELECT * FROM read_parquet('{transition_file}')"
+        )
+        
+    if (
+        os.path.exists(alignment_file)
+        and os.path.basename(alignment_file) == "feature_alignment.parquet"
+    ):
+        con.execute(
+            f"CREATE VIEW alignment_features AS SELECT * FROM read_parquet('{alignment_file}')"
+        )
+
+    if level == "ms2" or level == "ms1ms2":
+        if not any(
+            [col.startswith("FEATURE_MS2_") for col in all_precursor_column_names]
+        ):
+            raise click.ClickException(
+                "MS2-level feature columns are not present in precursors_features.parquet file."
+            )
+
+        # Filter columes names for FEATURE_MS2_
+        feature_ms2_cols = [
+            col for col in all_precursor_column_names if col.startswith("FEATURE_MS2_")
+        ]
+        # prepare feature ms2 columns for sql query
+        feature_ms2_cols_sql = ", ".join([f"p.{col}" for col in feature_ms2_cols])
+
+        query = f"""
+        SELECT 
+            p.RUN_ID, 
+            p.PRECURSOR_ID, 
+            p.PRECURSOR_CHARGE, 
+            p.FEATURE_ID, 
+            p.EXP_RT, 
+            p.PRECURSOR_DECOY AS DECOY, 
+            {feature_ms2_cols_sql},
+            COALESCE(t.TRANSITION_COUNT, 0) AS TRANSITION_COUNT,
+            p.RUN_ID || '_' || p.PRECURSOR_ID AS GROUP_ID
+        FROM precursors p
+        LEFT JOIN (
+            SELECT 
+                PRECURSOR_ID, 
+                COUNT(*) AS TRANSITION_COUNT
+            FROM (
+                SELECT DISTINCT PRECURSOR_ID, TRANSITION_ID
+                FROM transitions
+                WHERE TRANSITION_DETECTING = 1
+            ) AS sub
+            GROUP BY PRECURSOR_ID
+        ) AS t
+        ON p.PRECURSOR_ID = t.PRECURSOR_ID
+        ORDER BY p.RUN_ID, p.PRECURSOR_ID ASC, p.EXP_RT ASC
+        """
+        table = con.execute(query).pl()
+
+        # Rename columns
+        table = table.rename(
+            {
+                **{
+                    col: col.replace("FEATURE_MS2_", "")
+                    for col in table.columns
+                    if col.startswith("FEATURE_MS2_")
+                }
+            }
+        )
+
+        table = table.to_pandas()
+
+    elif level == "ms1":
+        if not any(
+            [col.startswith("FEATURE_MS1_") for col in all_precursor_column_names]
+        ):
+            raise click.ClickException(
+                "MS1-level feature columns are not present in precursors_features.parquet file."
+            )
+
+        # Filter columes names for FEATURE_MS1_
+        feature_ms1_cols = [
+            col for col in all_precursor_column_names if col.startswith("FEATURE_MS1_")
+        ]
+        # prepare feature ms1 columns for sql query
+        feature_ms1_cols_sql = ", ".join([f"p.{col}" for col in feature_ms1_cols])
+
+        query = f"""
+                SELECT 
+                    p.RUN_ID, 
+                    p.PRECURSOR_ID, 
+                    p.PRECURSOR_CHARGE, 
+                    p.FEATURE_ID, 
+                    p.EXP_RT, 
+                    p.PRECURSOR_DECOY AS DECOY, 
+                    {feature_ms1_cols_sql},
+                    p.RUN_ID || '_' || p.PRECURSOR_ID AS GROUP_ID
+                FROM precursors p
+                ORDER BY p.RUN_ID, p.PRECURSOR_ID ASC, p.EXP_RT ASC
+                """
+        table = con.execute(query).pl()
+
+        # Rename columns
+        table = table.rename(
+            {
+                **{
+                    col: col.replace("FEATURE_MS1_", "")
+                    for col in table.columns
+                    if col.startswith("FEATURE_MS1_")
+                }
+            }
+        )
+        table = table.to_pandas()
+
+    elif level == "transition":
+        if not any(
+            [col.startswith("SCORE_MS2_") for col in all_precursor_column_names]
+        ):
+            raise click.ClickException(
+                "Transition-level scoring for IPF requires prior MS2 or MS1MS2-level scoring. Please run 'pyprophet score --level=ms2' or 'pyprophet score --level=ms1ms2' first."
+            )
+        if not any(
+            [
+                col.startswith("FEATURE_TRANSITION_")
+                for col in all_transition_column_names
+            ]
+        ):
+            raise click.ClickException(
+                "Transition-level feature columns are not present in transition_features.parquet file."
+            )
+
+        # Filter columes names for FEATURE_MS1_
+        feature_transition_cols = [
+            col
+            for col in all_transition_column_names
+            if col.startswith("FEATURE_TRANSITION_VAR")
+        ]
+        # prepare feature ms1 columns for sql query
+        feature_transition_cols_sql = ", ".join(
+            [f"t.{col}" for col in feature_transition_cols]
+        )
+
+        query = f"""
+        SELECT 
+            t.TRANSITION_DECOY AS DECOY,
+            t.FEATURE_ID AS FEATURE_ID,
+            t.TRANSITION_ID AS TRANSITION_ID,
+            {feature_transition_cols_sql},
+            p.PRECURSOR_CHARGE AS PRECURSOR_CHARGE,
+            t.TRANSITION_CHARGE AS PRODUCT_CHARGE,
+            p.RUN_ID || '_' || t.FEATURE_ID || '_' || t.TRANSITION_ID AS GROUP_ID
+        FROM transitions t
+        INNER JOIN precursors p ON t.PRECURSOR_ID = p.PRECURSOR_ID AND t.FEATURE_ID = p.FEATURE_ID
+        WHERE p.SCORE_MS2_RANK <= {ipf_max_peakgroup_rank}
+        AND p.SCORE_MS2_PEP <= {ipf_max_peakgroup_pep}
+        AND p.PRECURSOR_DECOY = 0
+        AND t.FEATURE_TRANSITION_VAR_ISOTOPE_OVERLAP_SCORE <= {ipf_max_transition_isotope_overlap}
+        AND t.FEATURE_TRANSITION_VAR_LOG_SN_SCORE > {ipf_min_transition_sn}
+        ORDER BY p.RUN_ID, p.PRECURSOR_ID, p.EXP_RT, t.TRANSITION_ID
+        """
+        table = con.execute(query).pl()
+
+        # Rename columns
+        table = table.rename(
+            {
+                **{
+                    col: col.replace("FEATURE_TRANSITION_", "")
+                    for col in table.columns
+                    if col.startswith("FEATURE_TRANSITION_")
+                }
+            }
+        )
+        table = table.to_pandas()
+
+    elif level == "alignment":
+        feature_alignment_cols =[
+            col
+            for col in all_alignment_column_names
+            if col.startswith("VAR_")
+        ]
+        # Prepare alignment query
+        feature_alignment_cols_sql = ", ".join(
+            [f"a.{col}" for col in feature_alignment_cols]
+        )
+
+        query = f"""
+        SELECT 
+            a.ALIGNMENT_ID,
+            a.RUN_ID, 
+            a.PRECURSOR_ID, 
+            a.FEATURE_ID, 
+            a.ALIGNED_RT, 
+            a.DECOY, 
+            {feature_alignment_cols_sql},
+            a.RUN_ID || '_' || a.FEATURE_ID || '_' || a.PRECURSOR_ID AS GROUP_ID
+        FROM alignment_features a
+        ORDER BY a.RUN_ID, a.PRECURSOR_ID ASC, a.REFERENCE_RT ASC
+        """
+        table = con.execute(query).pl()
+
+        table = table.to_pandas()
+        #  Map DECOY to 1 and -1 to 0 and 1
+        table['DECOY'] = table['DECOY'].map({1: 0, -1: 1})
+
+    else:
+        raise click.ClickException("Unspecified data level selected.")
+
+    if level == "ms1ms2":
+        if not any(
+            [col.startswith("FEATURE_MS1_") for col in all_precursor_column_names]
+        ):
+            raise click.ClickException(
+                "MS1-level feature columns are not present in parquet file."
+            )
+
+        feature_ms1_cols = [
+            col
+            for col in all_precursor_column_names
+            if col.startswith("FEATURE_MS1_VAR")
+        ]
+        feature_ms1_cols_sql = ", ".join([f"p.{col}" for col in feature_ms1_cols])
+        query = f"""
+        SELECT 
+            p.FEATURE_ID, 
+            {feature_ms1_cols_sql}
+        FROM precursors p
+        """
+        ms1_table = con.execute(query).df()
+        table = pd.merge(table, ms1_table, how="left", on="FEATURE_ID")
+
+    table.columns = [col.lower() for col in table.columns]
+
+    if ss_main_score.lower() in table.columns:
+        table = table.rename(
+            columns={ss_main_score.lower(): "main_" + ss_main_score.lower()}
+        )
+    elif ss_main_score.lower() == "swath_pretrained":
+        # SWATH pretrained score is not really used anymore, so drop support for it in parquet file input workflow
+        raise click.ClickException(
+            "SWATH pretrained score not available for parquet files workflow"
+        )
+    else:
+        raise click.ClickException(
+            f"Main score ({ss_main_score.lower()}) column not present in data. Current columns: {table.columns}"
+        )
+
+    if classifier == "XGBoost" and level != "alignment":
+        click.echo(
+            "Info: Enable number of transitions & precursor / product charge scores for XGBoost-based classifier"
+        )
+        table = table.rename(
+            columns={
+                "precursor_charge": "var_precursor_charge",
+                "product_charge": "var_product_charge",
+                "transition_count": "var_transition_count",
+            }
+        )
+
+    return table

--- a/pyprophet/runner.py
+++ b/pyprophet/runner.py
@@ -8,7 +8,6 @@ import pandas as pd
 import numpy as np
 import polars as pl
 import sqlite3
-import duckdb
 import pickle
 
 from .pyprophet import PyProphet
@@ -992,125 +991,194 @@ class PyProphetRunner(object):
         if self.infile != self.outfile:
             copyfile(self.infile, self.outfile)
 
-        con = duckdb.connect()
-        con.execute(f"INSTALL parquet; LOAD parquet;")
-        con.execute(f"CREATE TABLE raw_data AS SELECT * FROM parquet_scan('{self.outfile}')")
+        if self.level == "ms2" or self.level == "ms1ms2":
+            # Read the parquet file
+            init_df = pl.read_parquet(self.outfile)
 
-        score_df = result.scored_tables.copy()
-        score_df.columns = [c.lower() for c in score_df.columns]
+            # Check and drop SCORE_MS2_ columns if they exist
+            score_ms2_cols = [col for col in init_df.columns if col.startswith("SCORE_MS2_")]
+            if score_ms2_cols:
+                click.echo(click.style("Warn: Dropping existing SCORE_MS2_ columns from the output file.", fg='yellow'))
+                init_df = init_df.drop(score_ms2_cols)
 
-        con.register("scores", score_df)
+            # Process the result scores
+            df = pl.from_pandas(result.scored_tables)
+            if 'h_score' in df.columns:
+                df = df.select([
+                    'feature_id', 'd_score', 'h_score', 'h0_score',
+                    'peak_group_rank', 'p_value', 'q_value', 'pep'
+                ])
+                df.columns = ['FEATURE_ID', 'SCORE', 'HSCORE', 'H0SCORE', 
+                            'RANK', 'PVALUE', 'QVALUE', 'PEP']
+            else:
+                df = df.select([
+                    'feature_id', 'd_score', 'peak_group_rank',
+                    'p_value', 'q_value', 'pep'
+                ])
+                df.columns = ['FEATURE_ID', 'SCORE', 'RANK', 'PVALUE', 'QVALUE', 'PEP']
 
-        if self.level in ("ms2", "ms1ms2"):
-            level_prefix = "score_ms2"
-            base_cols = ['feature_id', 'd_score', 'peak_group_rank', 'p_value', 'q_value', 'pep']
-            if 'h_score' in score_df.columns:
-                base_cols += ['h_score', 'h0_score']
-            score_cols = [f"{level_prefix}_{col.upper()}" for col in base_cols if col != 'feature_id']
+            # Add SCORE_MS2_ prefix to columns except FEATURE_ID
+            new_columns = ['FEATURE_ID'] + [f'SCORE_MS2_{col}' for col in df.columns[1:]]
+            df = df.rename(dict(zip(df.columns, new_columns)))
 
-            con.execute(f"""
-                CREATE OR REPLACE TABLE merged AS
-                SELECT
-                    r.*,
-                    s.d_score AS {level_prefix}_score,
-                    s.peak_group_rank AS {level_prefix}_rank,
-                    s.p_value AS {level_prefix}_pvalue,
-                    s.q_value AS {level_prefix}_qvalue,
-                    s.pep AS {level_prefix}_pep
-                    {", s.h_score AS " + level_prefix + "_hscore" if 'h_score' in score_df.columns else ""}
-                    {", s.h0_score AS " + level_prefix + "_h0score" if 'h0_score' in score_df.columns else ""}
-                FROM raw_data r
-                LEFT JOIN scores s ON r.feature_id = s.feature_id
-            """)
+            # Merge with initial dataframe
+            df = init_df.join(df, on='FEATURE_ID', how='left', coalesce=True)
 
+            # Write to parquet
+            df.write_parquet(
+                self.outfile,
+                compression="zstd",
+                compression_level=11
+            )
         elif self.level == "ms1":
-            level_prefix = "score_ms1"
-            base_cols = ['feature_id', 'd_score', 'peak_group_rank', 'p_value', 'q_value', 'pep']
-            if 'h_score' in score_df.columns:
-                base_cols += ['h_score', 'h0_score']
-            score_cols = [f"{level_prefix}_{col.upper()}" for col in base_cols if col != 'feature_id']
+            # Read the parquet file
+            init_df = pl.read_parquet(self.outfile)
 
-            con.execute(f"""
-                CREATE OR REPLACE TABLE merged AS
-                SELECT
-                    r.*,
-                    s.d_score AS {level_prefix}_score,
-                    s.peak_group_rank AS {level_prefix}_rank,
-                    s.p_value AS {level_prefix}_pvalue,
-                    s.q_value AS {level_prefix}_qvalue,
-                    s.pep AS {level_prefix}_pep
-                    {", s.h_score AS " + level_prefix + "_hscore" if 'h_score' in score_df.columns else ""}
-                    {", s.h0_score AS " + level_prefix + "_h0score" if 'h0_score' in score_df.columns else ""}
-                FROM raw_data r
-                LEFT JOIN scores s ON r.feature_id = s.feature_id
-            """)
+            # Check and drop SCORE_MS1_ columns if they exist
+            score_ms1_cols = [col for col in init_df.columns if col.startswith("SCORE_MS1_")]
+            if score_ms1_cols:
+                click.echo(click.style("Warn: Dropping existing SCORE_MS1_ columns from the output file.", fg='yellow'))
+                init_df = init_df.drop(score_ms1_cols)
 
+            # Process the result scores
+            df = pl.from_pandas(result.scored_tables)
+            if 'h_score' in df.columns:
+                df = df.select([
+                    'feature_id', 'd_score', 'h_score', 'h0_score',
+                    'peak_group_rank', 'p_value', 'q_value', 'pep'
+                ])
+                df = df.rename({
+                    'feature_id': 'FEATURE_ID',
+                    'd_score': 'SCORE',
+                    'h_score': 'HSCORE',
+                    'h0_score': 'H0SCORE',
+                    'peak_group_rank': 'RANK',
+                    'p_value': 'PVALUE',
+                    'q_value': 'QVALUE',
+                    'pep': 'PEP'
+                })
+            else:
+                df = df.select([
+                    'feature_id', 'd_score', 'peak_group_rank',
+                    'p_value', 'q_value', 'pep'
+                ])
+                df = df.rename({
+                    'feature_id': 'FEATURE_ID',
+                    'd_score': 'SCORE',
+                    'peak_group_rank': 'RANK',
+                    'p_value': 'PVALUE',
+                    'q_value': 'QVALUE',
+                    'pep': 'PEP'
+                })
+
+            # Add SCORE_MS1_ prefix to columns except FEATURE_ID
+            new_columns = {
+                col: f'SCORE_MS1_{col}' if col != 'FEATURE_ID' else col
+                for col in df.columns
+            }
+            df = df.rename(new_columns)
+
+            # Merge with initial dataframe
+            df = init_df.join(df, on='FEATURE_ID', how='left')
+
+            # Write to parquet
+            df.write_parquet(
+                self.outfile,
+                compression="zstd",
+                compression_level=11
+            )
         elif self.level == "transition":
-            level_prefix = "score_transition"
-            con.execute("""
-                CREATE OR REPLACE TABLE exploded AS
-                SELECT
-                    feature_id,
-                    unnest(transition_id) AS transition_id,
-                    *
-                FROM raw_data
-            """)
+            # Read the parquet file
+            init_df = pl.read_parquet(self.outfile)
 
-            con.execute(f"""
-                CREATE OR REPLACE TABLE merged_exploded AS
-                SELECT
-                    e.*,
-                    s.d_score AS {level_prefix}_score,
-                    s.peak_group_rank AS {level_prefix}_rank,
-                    s.p_value AS {level_prefix}_pvalue,
-                    s.q_value AS {level_prefix}_qvalue,
-                    s.pep AS {level_prefix}_pep
-                FROM exploded e
-                LEFT JOIN scores s
-                ON e.feature_id = s.feature_id AND e.transition_id = s.transition_id
-            """)
+            # Check and drop SCORE_TRANSITION_ columns if they exist
+            score_transition_cols = [col for col in init_df.columns if col.startswith("SCORE_TRANSITION_")]
+            if score_transition_cols:
+                click.echo(click.style("Warn: Dropping existing SCORE_TRANSITION_ columns from the output file.", fg='yellow'))
+                init_df = init_df.drop(score_transition_cols)
 
-            con.execute("""
-                CREATE OR REPLACE TABLE merged AS
-                SELECT * FROM merged_exploded
-            """)
+            # Get TRANSITION_ and FEATURE_TRANSITION_ columns and explode them
+            transition_cols = [col for col in init_df.columns if col.startswith('TRANSITION_') or col.startswith('FEATURE_TRANSITION_')]
+            transition_cols+=['PRODUCT_MZ', 'ANNOTATION', 'PEPTIDE_IPF_ID']
+            
+            # Create sub_init_df with only the transition columns to explode
+            sub_init_df = init_df.select(['PRECURSOR_ID', 'FEATURE_ID']+transition_cols)
+            sub_init_df = sub_init_df.explode(transition_cols)
+            
+            # Drop transition_cols from init_df
+            init_df = init_df.drop(transition_cols)
 
-        # Write to parquet
-        con.execute(f"""
-            COPY merged TO '{self.outfile}' (FORMAT 'parquet', COMPRESSION 'zstd')
-        """)
-        con.close()
+            # Process the scored tables
+            df = pl.DataFrame(result.scored_tables).select([
+                'feature_id', 'transition_id', 'd_score', 
+                'peak_group_rank', 'p_value', 'q_value', 'pep'
+            ]).rename({
+                'feature_id': 'FEATURE_ID',
+                'transition_id': 'TRANSITION_ID',
+                'd_score': 'SCORE',
+                'peak_group_rank': 'RANK',
+                'p_value': 'PVALUE',
+                'q_value': 'QVALUE',
+                'pep': 'PEP'
+            })
 
-        click.echo(f"Info: {self.outfile} written.")
+            # Add SCORE_TRANSITION_ prefix to columns except FEATURE_ID and TRANSITION_ID
+            df = df.rename({
+                col: f'SCORE_TRANSITION_{col}' 
+                for col in df.columns 
+                if col not in ['FEATURE_ID', 'TRANSITION_ID']
+            })
 
+            # Merge with initial dataframe
+            df = sub_init_df.join(
+                df, 
+                on=['FEATURE_ID', 'TRANSITION_ID'], 
+                how='left',
+                coalesce=True
+            )
+            
+            del sub_init_df
+
+            # Identify columns to group by (non-transition columns except PRODUCT_MZ and ANNOTATION)
+            collapse_columns = [
+                col for col in df.columns 
+                if not any(col.startswith(prefix) for prefix in ['TRANSITION_', 'FEATURE_TRANSITION_', 'SCORE_TRANSITION_'])
+                and col not in ['PRODUCT_MZ', 'ANNOTATION', 'PEPTIDE_IPF_ID']
+            ]
+
+            # Group and aggregate
+            df = df.group_by(collapse_columns).agg(pl.all())
+            
+            # Merge with init_df
+            df = init_df.join(
+                df, 
+                on=['PRECURSOR_ID', 'FEATURE_ID'], 
+                how='left',
+                coalesce=True
+            )
+            
+            del init_df
+
+            # Write to parquet
+            df.write_parquet(
+                self.outfile,
+                compression="zstd",
+                compression_level=11
+            )
+        
+        click.echo("Info: %s written." % self.outfile)
+        
         if result.final_statistics is not None:
             cutoffs = result.final_statistics["cutoff"].values
             svalues = result.final_statistics["svalue"].values
             qvalues = result.final_statistics["qvalue"].values
 
-            pvalues = result.scored_tables.loc[
-                (result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 0)
-            ]["p_value"].values
-            top_targets = result.scored_tables.loc[
-                (result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 0)
-            ]["d_score"].values
-            top_decoys = result.scored_tables.loc[
-                (result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 1)
-            ]["d_score"].values
+            pvalues = result.scored_tables.loc[(result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 0)]["p_value"].values
+            top_targets = result.scored_tables.loc[(result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 0)]["d_score"].values
+            top_decoys = result.scored_tables.loc[(result.scored_tables.peak_group_rank == 1) & (result.scored_tables.decoy == 1)]["d_score"].values
 
-            save_report(
-                os.path.join(f"{self.prefix}_{self.level}_report.pdf"),
-                self.outfile,
-                top_decoys,
-                top_targets,
-                cutoffs,
-                svalues,
-                qvalues,
-                pvalues,
-                pi0,
-                self.color_palette,
-            )
-            click.echo(f"Info: {self.prefix}_{self.level}_report.pdf written.")
+            save_report(os.path.join(self.prefix + "_" + self.level + "_report.pdf"), self.outfile, top_decoys, top_targets, cutoffs, svalues, qvalues, pvalues, pi0, self.color_palette)
+            click.echo("Info: %s written." % os.path.join(self.prefix + "_" + self.level + "_report.pdf"))
 
 class PyProphetLearner(PyProphetRunner):
 


### PR DESCRIPTION
- Update parquet export to use duckdb views and copy for more efficient streaming and memory use. 
- Added the option to split the osw parquet into a directory of separate precursor data parquet and transition data parquet.
- Update scoring, ipf and level contexts for directory of split parquet inputs

Example
```
## Original OSW with 50 runs
merged.osw (275G)

## Conversion to split parquet
pyprophet export-parquet --in merged.osw --out merged.pq --scoring_format --split_transition_data

merged.pq (150G)
|-- precursors_features.parquet (7.7G)
|-- transition_features.parquet (143G)

## Scoring (pass the directory with split parquet)
pyprophet score --level ms1ms2 --in merged.pq
pyprophet score --level transition --in merged.pq

## IPF
pyprophet ipf --in merged.pq

## Context level scoring
pyprophet peptide --in merged.pq --context global
pyprophet protein --in merged.pq --context global
```

### Enhancements to Parquet File Handling:
* Added a new utility function `is_valid_split_parquet_dir` to validate directories containing split Parquet files (`precursors_features.parquet` and `transition_features.parquet`). This ensures that both required files exist and are valid Parquet files. (`pyprophet/data_handling.py`, [pyprophet/data_handling.pyR139-R161](diffhunk://#diff-03e7ee761782762e3ebbc3126767d5e38e1c1071af73e0976fc0f02412a16e7eR139-R161))
* Introduced new methods `read_pyp_parquet_dir_peakgroup_precursor` and `read_pyp_parquet_dir_transition` to handle reading data from split Parquet directories. These methods support precursor-level and transition-level data processing. (`pyprophet/ipf.py`, [[1]](diffhunk://#diff-e4467a21f16cf1d3675a60cc904da7f9edf90842264405727e02a1f8ad068439R526-R723) [[2]](diffhunk://#diff-e4467a21f16cf1d3675a60cc904da7f9edf90842264405727e02a1f8ad068439R924-R976)

### Export Functionality Improvements:
* Added a `--split_transition_data` option to the `export_parquet` command, allowing users to export data into separate Parquet files for precursors and transitions. This provides better organization and compatibility with downstream tools. (`pyprophet/main.py`, [pyprophet/main.pyR571-R672](diffhunk://#diff-8da304718980ac3b91fcd2adc8868136a7fb3d3fa596151858815e40404e1e14R571-R672))
* Updated the Parquet file export logic to handle existing `SCORE_IPF_` columns by dropping them before writing new scores, ensuring data consistency. (`pyprophet/ipf.py`, [pyprophet/ipf.pyR1048-R1090](diffhunk://#diff-e4467a21f16cf1d3675a60cc904da7f9edf90842264405727e02a1f8ad068439R1048-R1090))
