### PR TITLE
fix pypdf out of date

### DIFF
--- a/pyprophet/report.py
+++ b/pyprophet/report.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     plt = None
 
-from pypdf import PdfMerger, PdfReader
+from pypdf import PdfWriter, PdfReader
 import sys
 import os
 
@@ -1508,7 +1508,7 @@ def main_score_selection_report(
         )
 
     # Create output to merge pdges
-    output = PdfMerger()
+    output = PdfWriter()
     # Generate colors
     t_col, d_col = color_blind_friendly(color_palette)
 


### PR DESCRIPTION
When trying to run with --main_score_selection_report got an error that Pdf_merger() is deprecated. Replaced this with pdf_writer()
