### PR TITLE
change explode to using polars

### DIFF
--- a/pyprophet/io/_base.py
+++ b/pyprophet/io/_base.py
@@ -384,7 +384,9 @@ class BaseWriter(ABC):
             #     logger.info(
             #         "Exploding protein_id column to handle multiple proteins per feature."
             #     )
-            df = df.explode("protein_id")
+            pl_df = pl.from_pandas(df)
+            pl_df = pl_df.explode("protein_id")
+            df = pl_df.to_pandas()
 
         if level == "transition":
             if self.file_type in ("parquet", "parquet_split", "parquet_split_multi"):


### PR DESCRIPTION
With one of my datasets, pandas explode consumes a lot of memory and causes pyprophet to crash. Switching to polars should be functionally equivalent, and a lot faster and more memory efficient. 

I am unsure if this breaks any tests 