### PR TITLE
feat: support tuple input for lambda in pi0est function

### DIFF
--- a/pyprophet/stats.py
+++ b/pyprophet/stats.py
@@ -190,6 +190,10 @@ def pi0est(
     if isinstance(lambda_, np.ndarray):
         ll = len(lambda_)
         lambda_ = np.sort(lambda_)
+    elif isinstance(lambda_, tuple) and len(lambda_) == 3:
+        lambda_ = np.arange(lambda_[0], lambda_[1], lambda_[2])
+        ll = len(lambda_)
+        lambda_ = np.sort(lambda_)
 
     if min(p) < 0 or max(p) > 1:
         raise click.ClickException("p-values not in valid range [0,1].")


### PR DESCRIPTION
This pull request introduces an enhancement to the `pi0est` function in `pyprophet/stats.py`, improving its flexibility in handling the `lambda_` parameter.

Parameter handling improvement:

* The `pi0est` function now accepts a tuple of three values for `lambda_`, which is interpreted as a range and converted to a sorted numpy array using `np.arange`. This allows users to specify a start, stop, and step for the range of lambda values, making the function more versatile.