### PR TITLE
Refactor SQL queries and add auto-subsampling feature

### DIFF
--- a/pyprophet/cli/score.py
+++ b/pyprophet/cli/score.py
@@ -396,7 +396,7 @@ def score(
     # Validate file type and subsample ratio. OSW, parquet, parquet_split, and parquet_split_multi all support subsampling
     if (
         config.file_type not in ["osw", "parquet", "parquet_split", "parquet_split_multi"]
-        and subsample_ratio < 1.0
+        and config.subsample_ratio < 1.0
     ):
         logger.warning(
             "Semi-supervised learning on a subset of the data, and then applying the weights to the full data is currently only supported for OSW, `parquet`, `parquet_split`, and `parquet_split_multi` files.\nFor TSV and other formats, you need to manually prepare a subsampled input file.\nSetting subsample_ratio to 1.0.",

--- a/pyprophet/cli/score.py
+++ b/pyprophet/cli/score.py
@@ -12,6 +12,7 @@ from .util import (
     memray_profile,
 )
 from .._config import RunnerIOConfig
+from ..io.util import get_num_runs
 # Defer import of runner to avoid premature sklearn import before OMP_NUM_THREADS is set
 # from ..scoring.runner import PyProphetLearner, PyProphetWeightApplier
 
@@ -37,7 +38,7 @@ from .._config import RunnerIOConfig
     default=1.0,
     show_default=True,
     type=float,
-    help="Subsampling ratio for large data. Use <1.0 to subsample precursors for semi-supervised learning, the learned weights will then be applied to the full data set.",
+    help="Subsampling ratio for large data. Use <1.0 to subsample precursors for semi-supervised learning, the learned weights will then be applied to the full data set. When set to 1.0 (default) and the input has >20 runs, auto-subsampling to 1/N is applied (N=number of runs). Set to -1.0 to disable auto-subsampling and use full data.",
 )
 # Semi-supervised learning
 @click.option(
@@ -372,6 +373,25 @@ def score(
         f"{config.prefix}_pyp_score_{level}.log",
         ctx.obj["LOG_HEADER"],
     )
+
+    # Auto-subsample based on number of runs if applicable
+    if subsample_ratio == 1.0:
+        # Check if we should auto-subsample
+        num_runs = get_num_runs(infile, config.file_type)
+        if num_runs > 20:
+            config.subsample_ratio = 1.0 / num_runs
+            logger.info(
+                f"Auto-subsampling enabled: {num_runs} runs detected. "
+                f"Setting subsample_ratio to 1/{num_runs} = {config.subsample_ratio:.4f} "
+                f"for efficient semi-supervised learning. Use --subsample_ratio -1 to disable auto-subsampling."
+            )
+    elif subsample_ratio == -1.0:
+        # User explicitly disabled auto-subsampling
+        config.subsample_ratio = 1.0
+        logger.info(
+            "Auto-subsampling disabled (subsample_ratio set to -1.0). "
+            "Using full dataset for semi-supervised learning."
+        )
 
     # Validate file type and subsample ratio. OSW, parquet, parquet_split, and parquet_split_multi all support subsampling
     if (

--- a/pyprophet/io/ipf/osw.py
+++ b/pyprophet/io/ipf/osw.py
@@ -335,12 +335,12 @@ class OSWReader(BaseOSWReader):
                 WHERE fma.LABEL = 1
                 AND fma.REFERENCE_FEATURE_ID != fma.ALIGNED_FEATURE_ID
             ) AS merged
-            LEFT JOIN (
+            INNER JOIN (
                 SELECT 
                     FEATURE_ID,
                     MIN(PEP) AS pep
                 FROM osw.SCORE_ALIGNMENT
-                WHERE PEP <= {pep_threshold}
+                WHERE PEP < {pep_threshold}
                 GROUP BY FEATURE_ID
             ) AS sa
             ON merged.FEATURE_ID = sa.FEATURE_ID
@@ -545,18 +545,32 @@ class OSWReader(BaseOSWReader):
         query = f"""
             SELECT  
                 DENSE_RANK() OVER (ORDER BY PRECURSOR_ID, ALIGNMENT_ID) AS ALIGNMENT_GROUP_ID,
-                ALIGNED_FEATURE_ID AS FEATURE_ID 
+                FEATURE_ID 
             FROM (
-                SELECT DISTINCT * FROM FEATURE_MS2_ALIGNMENT
-            ) AS FEATURE_MS2_ALIGNMENT
+                SELECT DISTINCT
+                    ALIGNMENT_ID,
+                    PRECURSOR_ID,
+                    REFERENCE_FEATURE_ID AS FEATURE_ID
+                FROM FEATURE_MS2_ALIGNMENT
+                WHERE LABEL = 1
+                AND REFERENCE_FEATURE_ID != ALIGNED_FEATURE_ID
+                
+                UNION
+                
+                SELECT DISTINCT
+                    ALIGNMENT_ID,
+                    PRECURSOR_ID,
+                    ALIGNED_FEATURE_ID AS FEATURE_ID
+                FROM FEATURE_MS2_ALIGNMENT
+                WHERE LABEL = 1
+                AND REFERENCE_FEATURE_ID != ALIGNED_FEATURE_ID
+            ) AS feature_list
             INNER JOIN (
-                SELECT DISTINCT *, MIN(QVALUE) 
+                SELECT DISTINCT FEATURE_ID
                 FROM SCORE_ALIGNMENT 
-                GROUP BY FEATURE_ID
-            ) AS SCORE_ALIGNMENT 
-            ON SCORE_ALIGNMENT.FEATURE_ID = FEATURE_MS2_ALIGNMENT.ALIGNED_FEATURE_ID
-            WHERE LABEL = 1
-            AND SCORE_ALIGNMENT.PEP < {pep_threshold}
+                WHERE PEP < {pep_threshold}
+            ) AS good_alignments 
+            ON good_alignments.FEATURE_ID = feature_list.FEATURE_ID
             ORDER BY ALIGNMENT_GROUP_ID
         """
 

--- a/pyprophet/io/util.py
+++ b/pyprophet/io/util.py
@@ -465,6 +465,81 @@ def print_parquet_tree(root_dir, precursors, transitions, alignment=None, max_ru
         click.echo(f"    └── 📄 {os.path.basename(alignment)}")
 
 
+def get_num_runs(infile, file_type):
+    """
+    Get the number of runs in the input file.
+
+    Supports OSW (SQLite), Parquet, Parquet split, and Parquet split multi formats.
+
+    Args:
+        infile (str): Path to the input file or directory.
+        file_type (str): Type of input file ('osw', 'parquet', 'parquet_split', 'parquet_split_multi', 'tsv').
+
+    Returns:
+        int: Number of runs in the input file, or 0 if unable to determine.
+    """
+    try:
+        if file_type == "osw":
+            # Query RUN table from SQLite database
+            if not is_sqlite_file(infile):
+                return 0
+
+            con = sqlite3.connect(infile)
+            try:
+                cursor = con.cursor()
+                cursor.execute("SELECT COUNT(*) FROM RUN")
+                num_runs = cursor.fetchone()[0]
+                return num_runs
+            except sqlite3.OperationalError:
+                # RUN table doesn't exist
+                return 0
+            finally:
+                con.close()
+
+        elif file_type == "parquet":
+            # Single parquet file - need to check RUN_ID column
+            if not is_parquet_file(infile):
+                return 0
+
+            try:
+                df = pd.read_parquet(infile, columns=["RUN_ID"])
+                return df["RUN_ID"].nunique()
+            except Exception:
+                return 0
+
+        elif file_type == "parquet_split":
+            # Single-run split parquet directory
+            precursor_path = os.path.join(infile, "precursors_features.parquet")
+            if os.path.exists(precursor_path) and is_parquet_file(precursor_path):
+                try:
+                    df = pd.read_parquet(precursor_path, columns=["RUN_ID"])
+                    return df["RUN_ID"].nunique()
+                except Exception:
+                    return 0
+            return 0
+
+        elif file_type == "parquet_split_multi":
+            # Multi-run split parquet directory - count .oswpq subdirectories
+            if not os.path.isdir(infile):
+                return 0
+
+            # Each .oswpq directory represents one run
+            runs = [
+                d for d in os.listdir(infile)
+                if d.endswith(".oswpq") and os.path.isdir(os.path.join(infile, d))
+            ]
+            return len(runs)
+
+        elif file_type == "tsv":
+            return 1
+
+        return 0
+
+    except Exception as e:
+        logger.warning(f"Error getting number of runs from {infile}: {e}")
+        return 0
+
+
 def unimod_to_codename(seq):
     """
     Convert a sequence with unimod modifications to a codename.

--- a/pyprophet/io/util.py
+++ b/pyprophet/io/util.py
@@ -497,25 +497,27 @@ def get_num_runs(infile, file_type):
                 con.close()
 
         elif file_type == "parquet":
-            # Single parquet file - need to check RUN_ID column
+            # Single parquet file - use DuckDB for efficient streaming count
             if not is_parquet_file(infile):
                 return 0
 
             try:
-                df = pd.read_parquet(infile, columns=["RUN_ID"])
-                return df["RUN_ID"].nunique()
+                con = duckdb.connect()
+                query = f"""
+                    SELECT COUNT(DISTINCT RUN_ID) as num_runs
+                    FROM read_parquet('{infile}')
+                """
+                result = con.execute(query).fetchone()
+                return result[0] if result else 0
             except Exception:
                 return 0
 
         elif file_type == "parquet_split":
-            # Single-run split parquet directory
+            # Single-run split parquet directory - by definition, there is only 1 run
+            # (parquet_split is validated to contain one set of run files)
             precursor_path = os.path.join(infile, "precursors_features.parquet")
             if os.path.exists(precursor_path) and is_parquet_file(precursor_path):
-                try:
-                    df = pd.read_parquet(precursor_path, columns=["RUN_ID"])
-                    return df["RUN_ID"].nunique()
-                except Exception:
-                    return 0
+                return 1
             return 0
 
         elif file_type == "parquet_split_multi":


### PR DESCRIPTION
This pull request introduces an automatic subsampling feature for semi-supervised learning in the scoring workflow, aiming to improve efficiency when handling large datasets with many runs. Additionally, it makes several improvements and corrections to alignment feature queries and adds a utility function for determining the number of runs in various file formats.

**Automatic subsampling and scoring improvements:**

* Added logic in `score.py` to automatically set the `subsample_ratio` to `1/N` (where N is the number of runs) when the default value is used and the input contains more than 20 runs, optimizing performance for large datasets. Users can disable this auto-subsampling by setting `--subsample_ratio -1`. The CLI help text was updated to document this behavior. [[1]](diffhunk://#diff-6b0acac28265c8e1020319dc599503c9094bbbbf62c9faa5c03af4d3327e6d1aL40-R41) [[2]](diffhunk://#diff-6b0acac28265c8e1020319dc599503c9094bbbbf62c9faa5c03af4d3327e6d1aR377-R395) [[3]](diffhunk://#diff-6b0acac28265c8e1020319dc599503c9094bbbbf62c9faa5c03af4d3327e6d1aR15)

**Alignment feature query corrections:**

* Changed a `LEFT JOIN` to an `INNER JOIN` and made the PEP threshold exclusive in the DuckDB alignment feature query, ensuring only features with PEP strictly less than the threshold are included.
* Refactored the SQLite alignment feature query to correctly select and join features, handle groupings, and apply the PEP threshold, improving data accuracy and compatibility.

**Utility enhancements:**

* Added a new `get_num_runs` function in `io/util.py` to robustly determine the number of runs in input files across supported formats (OSW, Parquet, split Parquet, and TSV), supporting the new auto-subsampling logic.