### PR TITLE
Add exclude_decoys option and filtering in BaseWriter

### DIFF
--- a/pyprophet/_config.py
+++ b/pyprophet/_config.py
@@ -717,3 +717,6 @@ class ExportIOConfig(BaseIOConfig):
     min_fragments: int = 4
     keep_decoys: bool = False  # Whether to keep decoy entries in the library
     rt_unit: Literal["iRT", "RT"] = "iRT"
+
+    # TSV/Matrix export options
+    exclude_decoys: bool = True  # Whether to exclude decoy entries from TSV/matrix export (default: True, exclude decoys)

--- a/pyprophet/cli/export.py
+++ b/pyprophet/cli/export.py
@@ -159,6 +159,13 @@ def create_export_group():
     type=float,
     help="[format: matrix/legacy] Maximum PEP to consider for good alignments when use_alignment is enabled.",
 )
+@click.option(
+    "--exclude-decoys/--no-exclude-decoys",
+    "exclude_decoys",
+    default=True,
+    show_default=True,
+    help="Exclude decoy entries from the exported results. Use --no-exclude-decoys to retain decoys.",
+)
 @measure_memory_usage_and_time
 def export_tsv(
     infile,
@@ -176,6 +183,7 @@ def export_tsv(
     max_global_protein_qvalue,
     use_alignment,
     max_alignment_pep,
+    exclude_decoys,
 ):
     """
     Export Proteomics/Peptidoform TSV/CSV tables
@@ -207,6 +215,7 @@ def export_tsv(
         max_global_protein_qvalue=max_global_protein_qvalue,
         use_alignment=use_alignment,
         max_alignment_pep=max_alignment_pep,
+        exclude_decoys=exclude_decoys,
     )
 
     reader = ReaderDispatcher.get_reader(config)
@@ -329,6 +338,13 @@ def export_tsv(
     type=click.Choice(["none", "median", "medianmedian", "quantile"]),
     help="[format: matrix/legacy] Normalization method to apply to the quantification matrix.",
 )
+@click.option(
+    "--exclude-decoys/--no-exclude-decoys",
+    "exclude_decoys",
+    default=True,
+    show_default=True,
+    help="Exclude decoy entries from the exported matrix. Use --no-exclude-decoys to retain decoys.",
+)
 @measure_memory_usage_and_time
 def export_matrix(
     infile,
@@ -347,6 +363,7 @@ def export_matrix(
     top_n,
     consistent_top,
     normalization,
+    exclude_decoys,
 ):
     """
     Export Proteomics/Peptidoform Quantification Matrix
@@ -381,6 +398,7 @@ def export_matrix(
         top_n=top_n,
         consistent_top=consistent_top,
         normalization=normalization,
+        exclude_decoys=exclude_decoys,
     )
 
     reader = ReaderDispatcher.get_reader(config)

--- a/pyprophet/io/_base.py
+++ b/pyprophet/io/_base.py
@@ -589,6 +589,14 @@ class BaseWriter(ABC):
         """
         cfg = self.config
 
+        # Filter out decoys if exclude_decoys is True
+        if cfg.exclude_decoys and "decoy" in data.columns:
+            initial_count = len(data)
+            data = data[data["decoy"] == 0]
+            decoy_count = initial_count - len(data)
+            if decoy_count > 0:
+                logger.info(f"Excluded {decoy_count} decoy entries from export.")
+
         sep = "," if cfg.out_type == "csv" else "\t"
 
         if cfg.export_format == "legacy_split":
@@ -736,6 +744,14 @@ class BaseWriter(ABC):
 
         """
         cfg = self.config
+
+        # Filter out decoys if exclude_decoys is True
+        if cfg.exclude_decoys and "decoy" in data.columns:
+            initial_count = len(data)
+            data = data[data["decoy"] == 0]
+            decoy_count = initial_count - len(data)
+            if decoy_count > 0:
+                logger.info(f"Excluded {decoy_count} decoy entries from quantification matrix.")
 
         # Check if data is empty
         if data.empty:

--- a/pyprophet/io/_base.py
+++ b/pyprophet/io/_base.py
@@ -592,7 +592,7 @@ class BaseWriter(ABC):
         # Filter out decoys if exclude_decoys is True
         if cfg.exclude_decoys and "decoy" in data.columns:
             initial_count = len(data)
-            data = data[data["decoy"] == 0]
+            data = data.loc[data["decoy"].eq(0)].copy()
             decoy_count = initial_count - len(data)
             if decoy_count > 0:
                 logger.info(f"Excluded {decoy_count} decoy entries from export.")


### PR DESCRIPTION
This pull request adds a new option to exclude decoy entries from TSV and quantification matrix exports, making it easier for users to control whether decoys are included in their output. The change introduces new CLI flags, updates configuration handling, and ensures decoys are filtered out when requested, with clear logging for transparency.

**New export options for decoy exclusion:**

* Added an `exclude_decoys` boolean option to the `ExportIOConfig` class in `pyprophet/_config.py` to control whether decoy entries are excluded during TSV/matrix export.

**CLI enhancements:**

* Introduced `--exclude-decoys/--no-exclude-decoys` flags to both the `export_tsv` and `export_matrix` commands in `pyprophet/cli/export.py`, defaulting to excluding decoys. The option is passed through the CLI and into the export configuration. [[1]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R162-R168) [[2]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R186) [[3]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R218) [[4]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R341-R347) [[5]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R366) [[6]](diffhunk://#diff-9fab6e03da38d5a85c462cecb1f44faa1b3795c7dc4f59c107458dadb0207ac8R401)

**Export logic updates:**

* Updated `export_results` and `export_quant_matrix` methods in `pyprophet/io/_base.py` to filter out decoy entries from the exported data if `exclude_decoys` is enabled, and added logging to report the number of excluded decoys. [[1]](diffhunk://#diff-c3c3455e6e350ff3585b766f3afe2a75d75d4f4b8aeab26bd0c53c7eb0db0160R592-R599) [[2]](diffhunk://#diff-c3c3455e6e350ff3585b766f3afe2a75d75d4f4b8aeab26bd0c53c7eb0db0160R748-R755)